### PR TITLE
chore: add custom deserializer for name or list of packages

### DIFF
--- a/src/actions/package/install.rs
+++ b/src/actions/package/install.rs
@@ -84,7 +84,7 @@ mod tests {
 
         match actions.pop() {
             Some(Actions::PackageInstall(package_install)) => {
-                assert_eq!(vec!["curl"], package_install.list);
+                assert_eq!(vec!["curl"], package_install.names);
             }
             _ => {
                 panic!("PackageInstall didn't deserialize to the correct type");
@@ -93,7 +93,7 @@ mod tests {
 
         match actions.pop() {
             Some(Actions::PackageInstall(package_install)) => {
-                assert_eq!("curl", package_install.name.unwrap());
+                assert_eq!(vec!["curl"], package_install.names);
             }
             _ => {
                 panic!("PackageInstall didn't deserialize to the correct type");


### PR DESCRIPTION
We add a little custom deserializer that can handle single strings or lists of strings.
That allows us to treat `name` and `list` from the YAML as a single field in Rust.