### PR TITLE
Bring docs and examples up-to-date with current schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ A manifest is a collection of packages and files, and this will likely be expand
 ```yaml
 actions:
   - action: command.run
-    name: whoami
+    command: whoami
+    dir: .
     sudo: true
 
   - action: command.run
-    name: echo
+    command: echo
+    dir: .
     args:
       - Hello
       - World

--- a/examples/command/run.yaml
+++ b/examples/command/run.yaml
@@ -1,9 +1,11 @@
 actions:
   - action: command.run
     command: echo
+    dir: .
     args:
       - hi
 
   - action: cmd.run
     command: whoami
+    dir: .
     sudo: true


### PR DESCRIPTION
Reading the code, it looks like `dir` is meant to be optional? There's code to default it to cwd, but I guess some YAML decoding layer is enforcing it as mandatory (locally-built 5378820)