### PR TITLE
Draft: Create an extension point to have action be run conditionally and have variants

### DIFF
--- a/src/actions/command/run.rs
+++ b/src/actions/command/run.rs
@@ -7,6 +7,8 @@ use tera::Context;
 pub struct RunCommand {
     pub command: String,
 
+    pub only: Option<String>,
+
     #[serde(default)]
     pub args: Vec<String>,
 
@@ -14,6 +16,19 @@ pub struct RunCommand {
     pub sudo: bool,
 
     pub dir: Option<String>,
+
+    #[serde(default)]
+    pub variants: Vec<Variant<RunCommand>>,
+}
+
+type Where = String;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Variant<T> {
+    #[serde(rename = "where")]
+    pub where_clause: Where,
+    #[serde(flatten)]
+    pub command: T,
 }
 
 fn get_false() -> bool {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -63,3 +63,37 @@ impl<E: std::error::Error> From<E> for ActionError {
 pub trait Action {
     fn plan(&self, manifest: &Manifest, context: &Context) -> Vec<Step>;
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::Actions;
+    use crate::manifests::Manifest;
+
+    #[test]
+    fn can_parse_some_advanced_stuff() {
+        let content = r#"
+actions:
+- action: command.run
+  only: user.username != "root"
+  command: echo
+  args:
+    - hi
+  variants:
+    - where: Debian
+      command: halt
+"#;
+        let m: Manifest = serde_yaml::from_str(content).unwrap();
+
+        let action = &m.actions[0];
+
+        let command = match action {
+            Actions::CommandRun(cr) => cr,
+            _ => panic!("did not get a command to run"),
+        };
+        assert_eq!(command.only, Some("user.username != \"root\"".into()));
+
+        let variant = &command.variants[0];
+        assert_eq!(variant.where_clause, "Debian");
+        assert_eq!(variant.command.command, "halt");
+    }
+}


### PR DESCRIPTION
This MR makes Serde happy and passes all tests. The following YAML now gets parsed correctly:
```yaml
actions:
- action: command.run
  only: user.username != "root"
  command: echo
  args:
    - hi
  variants:
    - where: Debian
      command: halt
```

But there will be more code needed to make it actually use `only` and `variants`.
