### PR TITLE
Add default package provider info for FreeBSD and DragonFly BSD

### DIFF
--- a/src/actions/package/providers/bsdpkg.rs
+++ b/src/actions/package/providers/bsdpkg.rs
@@ -79,7 +79,7 @@ impl PackageProvider for BsdPkg {
             Step {
                 atom: Box::new(Exec {
                     command: String::from("/usr/sbin/pkg"),
-                    arguments: vec![String::from("install")]
+                    arguments: vec![String::from("install"), String::from("-y")]
                         .into_iter()
                         .chain(package.extra_args.clone())
                         .chain(package.packages())

--- a/src/actions/package/providers/mod.rs
+++ b/src/actions/package/providers/mod.rs
@@ -47,6 +47,11 @@ impl Default for PackageProviders {
         let info = os_info::get();
 
         match info.os_type() {
+            // Arch Variants
+            os_info::Type::Arch=> PackageProviders::Yay,
+            os_info::Type::Manjaro=> PackageProviders::Yay,
+            // BSD operating systems
+            os_info::Type::FreeBSD=> PackageProviders::BsdPkg,
             // Debian / Ubuntu Variants
             os_info::Type::Debian => PackageProviders::Aptitude,
             os_info::Type::Mint => PackageProviders::Aptitude,
@@ -55,11 +60,9 @@ impl Default for PackageProviders {
             // For some reason, the Rust image is showing as this and
             // its Debian based?
             os_info::Type::OracleLinux => PackageProviders::Aptitude,
+            // Other
             os_info::Type::Macos => PackageProviders::Homebrew,
             os_info::Type::Windows => PackageProviders::Winget,
-            // Arch Variants
-            os_info::Type::Manjaro=> PackageProviders::Yay,
-            os_info::Type::Arch=> PackageProviders::Yay,
 
             _ => panic!("Sorry, but we don't have a default provider for {} OS. Please be explicit when requesting a package installation with `provider: XYZ`.", info.os_type()),
         }

--- a/src/actions/package/providers/mod.rs
+++ b/src/actions/package/providers/mod.rs
@@ -51,6 +51,7 @@ impl Default for PackageProviders {
             os_info::Type::Arch=> PackageProviders::Yay,
             os_info::Type::Manjaro=> PackageProviders::Yay,
             // BSD operating systems
+            os_info::Type::DragonFly=> PackageProviders::BsdPkg,
             os_info::Type::FreeBSD=> PackageProviders::BsdPkg,
             // Debian / Ubuntu Variants
             os_info::Type::Debian => PackageProviders::Aptitude,


### PR DESCRIPTION
Successfully tested installing packages on FreeBSD without specifying the provider in the manifest. Default provider tested for dfly, too. It works but there's an issue with the actual package installation that I need to look into separately.