### PR TITLE
fix: ensure we canonicalize manifest directory in-case it's a symlink

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn main() -> anyhow::Result<()> {
         });
 
     let manifest_directory = match manifest_directory {
-        Some(dir) => dir,
+        Some(dir) => dir.canonicalize().unwrap(),
         None => {
             error!("Failed to find manifests at {}", &manifest_location);
             panic!();


### PR DESCRIPTION
This is a problem because we attempt to "strip" the manifest directory as a prefix during some file.* operations and this fails when the path hasn't been resolved / canonicalized properly

Closes #146