### PR TITLE
[WIP] feat: Add support for DNF package manager for Red-Hat based distros

### DIFF
--- a/src/actions/package/providers/dnf.rs
+++ b/src/actions/package/providers/dnf.rs
@@ -1,0 +1,226 @@
+use super::PackageProvider;
+
+use crate::actions::package::PackageVariant;
+use crate::atoms::command::Exec;
+use crate::steps::Step;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+use which::which;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Dnf {}
+
+impl PackageProvider for Dnf {
+    fn name(&self) -> &str {
+        "DNF"
+    }
+
+    fn available(&self) -> bool {
+        match which("dnf") {
+            Ok(_) => true,
+            Err(_) => {
+                warn!(message = "dnf not available");
+                false
+            }
+        }
+    }
+
+    fn bootstrap(&self) -> Vec<Step> {
+        vec![Step {
+            atom: Box::new(Exec {
+                command: String::from("yum"),
+                arguments: vec![
+                    String::from("install"),
+                    String::from("--assumeyes"),
+                    String::from("dnf"),
+                ],
+                privileged: true,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }]
+    }
+
+    fn has_repository(&self, _package: &PackageVariant) -> bool {
+        false
+    }
+
+    fn add_repository(&self, package: &PackageVariant) -> Vec<Step> {
+        if package.repository.is_none() {
+            return vec![];
+        }
+
+        let mut steps: Vec<Step> = vec![];
+
+        if package.key.is_some() {
+            steps.extend(vec![Step {
+                atom: Box::new(Exec {
+                    command: String::from("rpm"),
+                    arguments: vec![String::from("--import"), package.key.clone().unwrap()],
+                    privileged: true,
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            }]);
+        }
+
+        steps.extend(vec![
+            Step {
+                atom: Box::new(Exec {
+                    command: String::from("dnf"),
+                    arguments: vec![
+                        String::from("config-manager"),
+                        String::from("--assumeyes"),
+                        String::from("--add-repo"),
+                        package.repository.clone().unwrap(),
+                    ],
+                    privileged: true,
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            },
+            Step {
+                atom: Box::new(Exec {
+                    command: String::from("dnf"),
+                    arguments: vec![
+                        String::from("update"),
+                        String::from("--assumeyes"),
+                        String::from("--refresh"),
+                    ],
+                    privileged: true,
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            },
+        ]);
+
+        steps
+    }
+
+    // TODO: What is the desired state for query(): to be package.packages() or to write custom code for each manager(like yay.rs and homebrew.rs, but not aptitude.rs)?
+    // I tried to implement query() for dnf by getting all installed packages "dnf list installed | awk '{print $1}'" and checking if they existed in package.packages,
+    // but I'm not entirely sure what the goal of query() is so for now I've left it as package.packages() and left the commented out code below
+    fn query(&self, package: &PackageVariant) -> Vec<String> {
+        package.packages()
+    }
+
+    // TODO: remove this commented out code, leaving here for now so reviewer can read
+    /*
+    fn query(&self, package: &PackageVariant) -> Vec<String> {
+        let requested_already_installed: HashSet<String> = String::from_utf8(
+            // dnf unfortunately doesn't have a package-name-only list option,
+            // so I used awk here to only print the package-names https://unix.stackexchange.com/questions/698003/how-to-tell-dnf-search-to-list-only-matches-in-the-pacakge-name-or-name-and-s
+            // TODO: should this below command be getting all installed packages?? Or is it meant to get dependencies of the package?
+            Command::new("dnf")
+                .args(vec![
+                    String::from("list"),
+                    String::from("installed"),
+                    // TODO: any better alternative to bash pipe or awk here?
+                    String::from("|"),
+                    String::from("awk"),
+                    String::from("'{print $1}'"),
+                ])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .sprint('\n')
+        .map(String::from)
+        .collect();
+
+        debug!(
+            "all requested installed packages: {:?}",
+            requested_already_installed
+        );
+        package
+            .packages()
+            .into_iter()
+            .filter(|p| {
+                if requested_already_installed.contains(p) {
+                    trace!("{}: already installed", p);
+                    false
+                } else {
+                    debug!("{}: doesn't appear to bew installed", p);
+                    true
+                }
+            })
+            .collect()
+    }
+    */
+
+    fn install(&self, package: &PackageVariant) -> Vec<Step> {
+        vec![Step {
+            atom: Box::new(Exec {
+                command: String::from("dnf"),
+                arguments: vec![
+                    String::from("install"),
+                    String::from("--assumeyes"),
+                    String::from("--quiet"),
+                ]
+                .into_iter()
+                .chain(package.extra_args.clone())
+                // TODO: OK to call self.query(package) directly here?
+                .chain(self.query(package))
+                .collect(),
+                privileged: true,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // TODO: Same as aptitude.rs, weak tests that should be updated in future
+
+    #[test]
+    fn test_add_repository_simple() {
+        let package = PackageVariant {
+            name: Some(String::from("test")),
+            ..Default::default()
+        };
+
+        let dnf = Dnf {};
+        let steps = dnf.add_repository(&package);
+
+        assert_eq!(steps.len(), 0);
+    }
+
+    #[test]
+    fn test_add_repository_without_key() {
+        let package = PackageVariant {
+            name: Some(String::from("test")),
+            repository: Some(String::from("repository")),
+            ..Default::default()
+        };
+
+        let dnf = Dnf {};
+        let steps = dnf.add_repository(&package);
+
+        assert_eq!(steps.len(), 2);
+    }
+
+    #[test]
+    fn test_repository_with_key() {
+        let package = PackageVariant {
+            name: Some(String::from("test")),
+            repository: Some(String::from("repository")),
+            key: Some(String::from("key")),
+            ..Default::default()
+        };
+
+        let dnf = Dnf {};
+        let steps = dnf.add_repository(&package);
+
+        assert_eq!(steps.len(), 3);
+    }
+}

--- a/src/actions/package/providers/mod.rs
+++ b/src/actions/package/providers/mod.rs
@@ -3,6 +3,8 @@ use self::aptitude::Aptitude;
 use crate::steps::Step;
 mod bsdpkg;
 use self::bsdpkg::BsdPkg;
+mod dnf;
+use self::dnf::Dnf;
 mod homebrew;
 use self::homebrew::Homebrew;
 mod pkgin;
@@ -22,6 +24,9 @@ pub enum PackageProviders {
     #[serde(alias = "bsdpkg")]
     BsdPkg,
 
+    #[serde(alias = "dnf", alias = "yum")]
+    Dnf,
+
     #[serde(alias = "homebrew", alias = "brew")]
     Homebrew,
 
@@ -40,6 +45,7 @@ impl PackageProviders {
         match self {
             PackageProviders::Aptitude => Box::new(Aptitude {}),
             PackageProviders::BsdPkg => Box::new(BsdPkg {}),
+            PackageProviders::Dnf => Box::new(Dnf {}),
             PackageProviders::Homebrew => Box::new(Homebrew {}),
             PackageProviders::Pkgin => Box::new(Pkgin {}),
             PackageProviders::Yay => Box::new(Yay {}),
@@ -68,6 +74,11 @@ impl Default for PackageProviders {
             // For some reason, the Rust image is showing as this and
             // its Debian based?
             os_info::Type::OracleLinux => PackageProviders::Aptitude,
+            // Red-Hat Variants
+            os_info::Type::Fedora => PackageProviders::Dnf,
+            os_info::Type::Redhat => PackageProviders::Dnf,
+            os_info::Type::RedHatEnterprise => PackageProviders::Dnf,
+            os_info::Type::CentOS => PackageProviders::Dnf,
             // Other
             os_info::Type::Macos => PackageProviders::Homebrew,
             os_info::Type::Windows => PackageProviders::Winget,


### PR DESCRIPTION
Hi, this is my first contribution to Comtrya - I think it's a great project and I use it for my own dotfiles management.

This pull request is to add DNF package manager support for Red-Hat based systems including Fedora, CentOS and RHEL. As a lot of users use Fedora or other Red-Hat based systems, I think its important that it's supported by Comtrya.

It is a **WIP**, I have added 5 TODOs in the non-test code that I would like a reviewer to check as I'm not sure of the best approach to them. Especially the use of the `query()` function, if the solution is to simply stick to using `package.packages()` then that is no problem and the commented out code can be removed.

Thanks for looking at my PR!

### Testing on Fedora 35
Unfortunately some of the detection for Fedora 35 from the dependency `os_info` is a bit off in the latest version v3.2.0 - as a W/A I installed lsb_release on my system for this testing: https://github.com/stanislav-tkach/os_info/pull/293

Since the fix is now merged in `os_info`, this can probably be resolved by updating it once the next version is released.

```
[~/repos/temp]$ command -v vim
[~/repos/temp]$ echo $?
1
[~/repos/temp]$ cat sample.yaml
actions:
  - action: package.install
    name: curl

  - action: package.install
    name: vim
[~/repos/temp]$ command -v curl
/usr/bin/curl
[~/repos/temp]$ ./comtrya .
 INFO manifest_run{manifest="sample"}: Step: RunCommand with privileged true: dnf install --assumeyes --quiet curl (Not printing initializers and finalizers yet)
 INFO manifest_run{manifest="sample"}: Sudo required for privilege elevation to run `sudo dnf install --assumeyes --quiet curl`. Validating sudo ...
 INFO manifest_run{manifest="sample"}: Step: RunCommand with privileged true: dnf install --assumeyes --quiet vim (Not printing initializers and finalizers yet)
 INFO manifest_run{manifest="sample"}: Sudo required for privilege elevation to run `sudo dnf install --assumeyes --quiet vim`. Validating sudo ...
 INFO manifest_run{manifest="sample"}: Completed
[~/repos/temp]$ command -v vim
/usr/bin/vim
[~/repos/temp]$ uname -a
Linux fedora 5.16.18-200.fc35.x86_64 #1 SMP PREEMPT Mon Mar 28 14:10:07 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
[~/repos/temp]$
```