### PR TITLE
Feature: Adding users via comtrya

### DIFF
--- a/examples/user/adduser.yaml
+++ b/examples/user/adduser.yaml
@@ -1,0 +1,6 @@
+actions:
+  - action: user.add
+    username: test
+    shell: sh
+    home_dir: /home/test
+    

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -18,8 +18,8 @@ use git::GitClone;
 use koto::{Koto, KotoSettings};
 use macos::MacOSDefault;
 use package::install::PackageInstall;
-use user::add::UserAdd;
 use serde::{Deserialize, Serialize};
+use user::add::UserAdd;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ConditionalVariantAction<T> {
@@ -138,7 +138,7 @@ pub enum Actions {
     #[serde(alias = "package.install", alias = "package.installed")]
     PackageInstall(ConditionalVariantAction<PackageInstall>),
 
-    #[serde(alias="user.add")]
+    #[serde(alias = "user.add")]
     UserAdd(ConditionalVariantAction<UserAdd>),
 }
 
@@ -154,7 +154,7 @@ impl Actions {
             Actions::GitClone(a) => a,
             Actions::MacOSDefault(a) => a,
             Actions::PackageInstall(a) => a,
-	    Actions::UserAdd(a) => a,
+            Actions::UserAdd(a) => a,
         }
     }
 }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -4,6 +4,7 @@ mod file;
 mod git;
 mod macos;
 mod package;
+mod user;
 
 use crate::contexts::{to_koto, Contexts};
 use crate::manifests::Manifest;
@@ -17,6 +18,7 @@ use git::GitClone;
 use koto::{Koto, KotoSettings};
 use macos::MacOSDefault;
 use package::install::PackageInstall;
+use user::add::UserAdd;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -135,6 +137,9 @@ pub enum Actions {
 
     #[serde(alias = "package.install", alias = "package.installed")]
     PackageInstall(ConditionalVariantAction<PackageInstall>),
+
+    #[serde(alias="user.add")]
+    UserAdd(ConditionalVariantAction<UserAdd>),
 }
 
 impl Actions {
@@ -149,6 +154,7 @@ impl Actions {
             Actions::GitClone(a) => a,
             Actions::MacOSDefault(a) => a,
             Actions::PackageInstall(a) => a,
+	    Actions::UserAdd(a) => a,
         }
     }
 }

--- a/src/actions/user/add.rs
+++ b/src/actions/user/add.rs
@@ -24,25 +24,6 @@ impl Action for UserAdd {
 
         let mut atoms: Vec<Step> = vec![];
 
-        // If the provider isn't available, see if we can bootstrap it
-        // if !provider.available() {
-        //     if provider.bootstrap().is_empty() {
-        //         error!(
-        //             "User Provider, {}, isn't available. Skipping action",
-        //             provider.name()
-        //         );
-        //         return vec![];
-        //     }
-
-        //     atoms.append(&mut provider.bootstrap());
-        // }
-
-        // if let Some(ref _repo) = variant.repository {
-        //     if !provider.has_repository(&variant) {
-        //         atoms.append(&mut provider.add_repository(&variant));
-        //     }
-        // }
-
         atoms.append(&mut provider.add_user(&variant));
 
         span.exit();
@@ -50,40 +31,3 @@ impl Action for UserAdd {
         atoms
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use crate::actions::Actions;
-
-//     #[test]
-//     fn it_can_be_deserialized() {
-//         let yaml = r#"
-// - action: package.install
-//   name: curl
-
-// - action: package.install
-//   list:
-//     - bash
-// "#;
-
-//         let mut actions: Vec<Actions> = serde_yaml::from_str(yaml).unwrap();
-
-//         match actions.pop() {
-//             Some(Actions::UserAdd(action)) => {
-//                 assert_eq!(vec!["bash"], action.action.list);
-//             }
-//             _ => {
-//                 panic!("UserAdd didn't deserialize to the correct type");
-//             }
-//         };
-
-//         match actions.pop() {
-//             Some(Actions::UserAdd(action)) => {
-//                 assert_eq!("curl", action.action.name.unwrap());
-//             }
-//             _ => {
-//                 panic!("UserAdd didn't deserialize to the correct type");
-//             }
-//         };
-//     }
-// }

--- a/src/actions/user/add.rs
+++ b/src/actions/user/add.rs
@@ -1,0 +1,89 @@
+use super::User;
+use super::UserVariant;
+use crate::actions::Action;
+use crate::contexts::Contexts;
+use crate::manifests::Manifest;
+use crate::steps::Step;
+use std::ops::Deref;
+use tracing::{error, span};
+
+pub type UserAdd = User;
+
+impl Action for UserAdd {
+    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> Vec<Step> {
+        let variant: UserVariant = self.into();
+        let box_provider = variant.provider.clone().get_provider();
+        let provider = box_provider.deref();
+
+        let span = span!(
+            tracing::Level::INFO,
+            "user.add",
+            // provider = provider.name()
+        )
+        .entered();
+
+        let mut atoms: Vec<Step> = vec![];
+
+        // If the provider isn't available, see if we can bootstrap it
+        // if !provider.available() {
+        //     if provider.bootstrap().is_empty() {
+        //         error!(
+        //             "User Provider, {}, isn't available. Skipping action",
+        //             provider.name()
+        //         );
+        //         return vec![];
+        //     }
+
+        //     atoms.append(&mut provider.bootstrap());
+        // }
+
+        // if let Some(ref _repo) = variant.repository {
+        //     if !provider.has_repository(&variant) {
+        //         atoms.append(&mut provider.add_repository(&variant));
+        //     }
+        // }
+
+        atoms.append(&mut provider.add_user(&variant));
+
+        span.exit();
+
+        atoms
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::actions::Actions;
+
+//     #[test]
+//     fn it_can_be_deserialized() {
+//         let yaml = r#"
+// - action: package.install
+//   name: curl
+
+// - action: package.install
+//   list:
+//     - bash
+// "#;
+
+//         let mut actions: Vec<Actions> = serde_yaml::from_str(yaml).unwrap();
+
+//         match actions.pop() {
+//             Some(Actions::UserAdd(action)) => {
+//                 assert_eq!(vec!["bash"], action.action.list);
+//             }
+//             _ => {
+//                 panic!("UserAdd didn't deserialize to the correct type");
+//             }
+//         };
+
+//         match actions.pop() {
+//             Some(Actions::UserAdd(action)) => {
+//                 assert_eq!("curl", action.action.name.unwrap());
+//             }
+//             _ => {
+//                 panic!("UserAdd didn't deserialize to the correct type");
+//             }
+//         };
+//     }
+// }

--- a/src/actions/user/mod.rs
+++ b/src/actions/user/mod.rs
@@ -1,0 +1,138 @@
+pub mod add;
+pub mod userproviders;
+
+use userproviders::UserProviders;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tracing::debug;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct User {
+    #[serde(default)]
+    provider: UserProviders,
+    
+    #[serde(default)]
+    username: String,
+
+    #[serde(default)]
+    home_dir: String,
+
+    #[serde(default)]
+    fullname: String,
+
+    #[serde(default)]
+    shell: String,
+
+    #[serde(default)]
+    uid: String,
+
+    #[serde(default)]
+    gid: String,
+
+    #[serde(default)]
+    password: String,
+
+    #[serde(default)]
+    variants: HashMap<os_info::Type, UserVariant>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct UserVariant {
+    #[serde(default)]
+    provider: UserProviders,
+    
+    #[serde(default)]
+    username: String,
+
+    #[serde(default)]
+    home_dir: String,
+    
+    #[serde(default)]
+    fullname: String,
+
+    #[serde(default)]
+    shell: String,
+
+    #[serde(default)]
+    uid: String,
+
+    #[serde(default)]
+    gid: String,
+
+    #[serde(default)]
+    password: String,
+
+    // #[serde(default)]
+    // extra_args: Vec<String>,
+}
+
+impl UserVariant {
+    fn users(&self) -> Vec<String> {
+	let string: Vec<String> = vec![];
+	string
+    }
+}
+
+impl From<&User> for UserVariant {
+    fn from(user: &User) -> Self {
+        let os = os_info::get();
+
+        // Check for variant configuration for this OS
+        let variant = user.variants.get(&os.os_type());
+
+        // No variant overlays
+        if variant.is_none() {
+            return UserVariant {
+		provider: user.provider.clone(),
+		username: user.username.clone(),
+		home_dir: user.home_dir.clone(),
+		fullname: user.fullname.clone(),
+		shell: user.shell.clone(),
+		uid: user.uid.clone(),
+		gid: user.gid.clone(),
+		password: user.password.clone(),
+            };
+        };
+
+        let variant = variant.unwrap();
+
+        debug!(message = "Built Variant", variant = ?variant);
+
+        let mut user = UserVariant {
+	    provider: user.provider.clone(),
+	    username: user.username.clone(),
+	    home_dir: user.home_dir.clone(),
+	    fullname: user.fullname.clone(),
+	    shell: user.shell.clone(),
+	    uid: user.uid.clone(),
+	    gid: user.gid.clone(),
+	    password: user.password.clone(),
+        };
+
+        // if variant.name.is_some() {
+        //     user.name = variant.name.clone();
+        // }
+
+        // if !variant.list.is_empty() {
+        //     user.list = variant.list.clone();
+        // }
+
+        // if variant.repository.is_some() {
+        //     user.repository = variant.repository.clone();
+        // };
+
+        // if variant.key.is_some() {
+        //     user.key = variant.key.clone();
+        // }
+
+        // I've been torn about this, but here's my logic.
+        // Variants, when being used, shouldn't use the provider
+        // of the main definition; as we're not the core OS.
+        // Even if the omission of a provider for a variant gets us
+        // the default, that's most likely still expected behaviour.
+        // Right?
+        user.provider = variant.provider.clone();
+
+        user
+    }
+}

--- a/src/actions/user/mod.rs
+++ b/src/actions/user/mod.rs
@@ -1,16 +1,16 @@
 pub mod add;
 pub mod userproviders;
 
-use userproviders::UserProviders;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::debug;
+use userproviders::UserProviders;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct User {
     #[serde(default)]
     provider: UserProviders,
-    
+
     #[serde(default)]
     username: String,
 
@@ -22,15 +22,6 @@ pub struct User {
 
     #[serde(default)]
     shell: String,
-
-    #[serde(default)]
-    uid: String,
-
-    #[serde(default)]
-    gid: String,
-
-    #[serde(default)]
-    password: String,
 
     #[serde(default)]
     variants: HashMap<os_info::Type, UserVariant>,
@@ -40,36 +31,24 @@ pub struct User {
 pub struct UserVariant {
     #[serde(default)]
     provider: UserProviders,
-    
+
     #[serde(default)]
     username: String,
 
     #[serde(default)]
     home_dir: String,
-    
+
     #[serde(default)]
     fullname: String,
 
     #[serde(default)]
     shell: String,
-
-    #[serde(default)]
-    uid: String,
-
-    #[serde(default)]
-    gid: String,
-
-    #[serde(default)]
-    password: String,
-
-    // #[serde(default)]
-    // extra_args: Vec<String>,
 }
 
 impl UserVariant {
     fn users(&self) -> Vec<String> {
-	let string: Vec<String> = vec![];
-	string
+        let string: Vec<String> = vec![];
+        string
     }
 }
 
@@ -83,14 +62,11 @@ impl From<&User> for UserVariant {
         // No variant overlays
         if variant.is_none() {
             return UserVariant {
-		provider: user.provider.clone(),
-		username: user.username.clone(),
-		home_dir: user.home_dir.clone(),
-		fullname: user.fullname.clone(),
-		shell: user.shell.clone(),
-		uid: user.uid.clone(),
-		gid: user.gid.clone(),
-		password: user.password.clone(),
+                provider: user.provider.clone(),
+                username: user.username.clone(),
+                home_dir: user.home_dir.clone(),
+                fullname: user.fullname.clone(),
+                shell: user.shell.clone(),
             };
         };
 
@@ -99,38 +75,13 @@ impl From<&User> for UserVariant {
         debug!(message = "Built Variant", variant = ?variant);
 
         let mut user = UserVariant {
-	    provider: user.provider.clone(),
-	    username: user.username.clone(),
-	    home_dir: user.home_dir.clone(),
-	    fullname: user.fullname.clone(),
-	    shell: user.shell.clone(),
-	    uid: user.uid.clone(),
-	    gid: user.gid.clone(),
-	    password: user.password.clone(),
+            provider: user.provider.clone(),
+            username: user.username.clone(),
+            home_dir: user.home_dir.clone(),
+            fullname: user.fullname.clone(),
+            shell: user.shell.clone(),
         };
 
-        // if variant.name.is_some() {
-        //     user.name = variant.name.clone();
-        // }
-
-        // if !variant.list.is_empty() {
-        //     user.list = variant.list.clone();
-        // }
-
-        // if variant.repository.is_some() {
-        //     user.repository = variant.repository.clone();
-        // };
-
-        // if variant.key.is_some() {
-        //     user.key = variant.key.clone();
-        // }
-
-        // I've been torn about this, but here's my logic.
-        // Variants, when being used, shouldn't use the provider
-        // of the main definition; as we're not the core OS.
-        // Even if the omission of a provider for a variant gets us
-        // the default, that's most likely still expected behaviour.
-        // Right?
         user.provider = variant.provider.clone();
 
         user

--- a/src/actions/user/userproviders/freebsd.rs
+++ b/src/actions/user/userproviders/freebsd.rs
@@ -1,0 +1,59 @@
+use super::UserProvider;
+use crate::steps::finalizers::FlowControl::StopIf;
+use crate::steps::finalizers::OutputContains;
+use crate::steps::Step;
+use crate::{actions::user::UserVariant, atoms::command::Exec};
+use serde::{Deserialize, Serialize};
+use tracing::{instrument, warn};
+use which::which;
+// use os_info;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FreeBSDUserProvider {}
+
+impl UserProvider for FreeBSDUserProvider {
+    fn add_user(&self, user: &UserVariant) -> Vec<Step> {
+
+	let mut args: Vec<String> = vec![];
+
+	if user.username.is_empty() {
+	    let blank: Vec<Step> = vec![];
+	    return blank;
+	}
+	
+	args.push(String::from("-n"));
+	args.push(user.username.clone());
+
+	if !user.home_dir.is_empty() {
+	    args.push(String::from("-m"));
+	    args.push(String::from("-d"));
+	    args.push(String::from(user.home_dir.clone()));
+	}
+
+	if !user.shell.is_empty() {
+	    args.push(String::from("-s"));
+	    args.push(user.shell.clone());
+	}
+
+	if !user.fullname.is_empty() {
+	    args.push(String::from("-c"));
+	    args.push(String::from(user.fullname.clone()));
+	}
+	
+        vec![
+            Step {
+		atom: Box::new(Exec {
+		    command: String::from("/usr/sbin/pw"),
+		    arguments: vec![String::from("useradd")]
+			.into_iter()
+			.chain(args.clone())
+			.collect(),
+		    privileged: true,
+		    ..Default::default()
+		}),
+		initializers: vec![],
+		finalizers: vec![],
+	    },
+        ]
+    }
+}

--- a/src/actions/user/userproviders/freebsd.rs
+++ b/src/actions/user/userproviders/freebsd.rs
@@ -13,47 +13,49 @@ pub struct FreeBSDUserProvider {}
 
 impl UserProvider for FreeBSDUserProvider {
     fn add_user(&self, user: &UserVariant) -> Vec<Step> {
+        let mut steps: Vec<Step> = vec![];
+        let mut args: Vec<String> = vec![];
 
-	let mut args: Vec<String> = vec![];
+        // is a user name isn't provided, cant create a new user
+        if user.username.is_empty() {
+            return steps;
+        }
 
-	if user.username.is_empty() {
-	    let blank: Vec<Step> = vec![];
-	    return blank;
-	}
-	
-	args.push(String::from("-n"));
-	args.push(user.username.clone());
+        args.push(String::from("-n"));
+        args.push(user.username.clone());
 
-	if !user.home_dir.is_empty() {
-	    args.push(String::from("-m"));
-	    args.push(String::from("-d"));
-	    args.push(String::from(user.home_dir.clone()));
-	}
+        if !user.home_dir.is_empty() {
+            args.push(String::from("-m"));
+            args.push(String::from("-d"));
+            args.push(String::from(user.home_dir.clone()));
+        }
 
-	if !user.shell.is_empty() {
-	    args.push(String::from("-s"));
-	    args.push(user.shell.clone());
-	}
+        if !user.shell.is_empty() {
+            args.push(String::from("-s"));
+            args.push(user.shell.clone());
+        }
 
-	if !user.fullname.is_empty() {
-	    args.push(String::from("-c"));
-	    args.push(String::from(user.fullname.clone()));
-	}
-	
-        vec![
-            Step {
-		atom: Box::new(Exec {
-		    command: String::from("/usr/sbin/pw"),
-		    arguments: vec![String::from("useradd")]
-			.into_iter()
-			.chain(args.clone())
-			.collect(),
-		    privileged: true,
-		    ..Default::default()
-		}),
-		initializers: vec![],
-		finalizers: vec![],
-	    },
-        ]
+        if !user.fullname.is_empty() {
+            args.push(String::from("-c"));
+            args.push(String::from(user.fullname.clone()));
+        }
+
+        // default to setting a randomly generated password
+        args.push(String::from("-w"));
+        args.push(String::from("random"));
+
+        vec![Step {
+            atom: Box::new(Exec {
+                command: String::from("/usr/sbin/pw"),
+                arguments: vec![String::from("useradd")]
+                    .into_iter()
+                    .chain(args.clone())
+                    .collect(),
+                privileged: true,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }]
     }
 }

--- a/src/actions/user/userproviders/mod.rs
+++ b/src/actions/user/userproviders/mod.rs
@@ -1,0 +1,43 @@
+mod freebsd;
+use self::freebsd::FreeBSDUserProvider;
+use crate::steps::Step;
+mod none;
+use self::none::NoneUserProvider;
+use super::UserVariant;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum UserProviders {
+    #[serde(alias = "freebsd")]
+    FreeBSDUserProvider,
+
+    #[serde(alias = "none")]
+    NoneUserProvider,
+}
+
+impl UserProviders {
+    pub fn get_provider(self) -> Box<dyn UserProvider> {
+        match self {
+            UserProviders::FreeBSDUserProvider => Box::new(FreeBSDUserProvider {}),
+	    UserProviders::NoneUserProvider => Box::new(NoneUserProvider {}),
+        }
+    }
+}
+
+impl Default for UserProviders {
+    fn default() -> Self {
+        let info = os_info::get();
+
+        match info.os_type() {
+	    // BSD Operating systems
+            os_info::Type::FreeBSD=> UserProviders::FreeBSDUserProvider,
+	    _ => UserProviders::NoneUserProvider,
+
+        //     _ => panic!("Sorry, but we don't have a default provider for {} OS. Please be explicit when requesting a package installation with `provider: XYZ`.", info.os_type()),
+        }
+    }
+}
+
+pub trait UserProvider {
+    fn add_user(&self, user: &UserVariant) -> Vec<Step>;
+}

--- a/src/actions/user/userproviders/mod.rs
+++ b/src/actions/user/userproviders/mod.rs
@@ -19,7 +19,7 @@ impl UserProviders {
     pub fn get_provider(self) -> Box<dyn UserProvider> {
         match self {
             UserProviders::FreeBSDUserProvider => Box::new(FreeBSDUserProvider {}),
-	    UserProviders::NoneUserProvider => Box::new(NoneUserProvider {}),
+            UserProviders::NoneUserProvider => Box::new(NoneUserProvider {}),
         }
     }
 }
@@ -29,11 +29,10 @@ impl Default for UserProviders {
         let info = os_info::get();
 
         match info.os_type() {
-	    // BSD Operating systems
-            os_info::Type::FreeBSD=> UserProviders::FreeBSDUserProvider,
-	    _ => UserProviders::NoneUserProvider,
-
-        //     _ => panic!("Sorry, but we don't have a default provider for {} OS. Please be explicit when requesting a package installation with `provider: XYZ`.", info.os_type()),
+            // BSD Operating systems
+            os_info::Type::FreeBSD => UserProviders::FreeBSDUserProvider,
+            _ => UserProviders::NoneUserProvider,
+            //     _ => panic!("Sorry, but we don't have a default provider for {} OS. Please be explicit when requesting a package installation with `provider: XYZ`.", info.os_type()),
         }
     }
 }

--- a/src/actions/user/userproviders/none.rs
+++ b/src/actions/user/userproviders/none.rs
@@ -1,0 +1,29 @@
+use super::UserProvider;
+use crate::steps::finalizers::FlowControl::StopIf;
+use crate::steps::finalizers::OutputContains;
+use crate::steps::Step;
+use crate::{actions::user::UserVariant, atoms::command::Exec};
+use serde::{Deserialize, Serialize};
+use tracing::{instrument, warn};
+use which::which;
+// use os_info;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct NoneUserProvider {}
+
+impl UserProvider for NoneUserProvider {
+    fn add_user(&self, user: &UserVariant) -> Vec<Step> {
+        vec![
+            Step {
+		atom: Box::new(Exec {
+		    command: String::from("/bin/echo"),
+		    arguments: vec![String::from("Hello World")],
+		    privileged: false,
+		    ..Default::default()
+		}),
+		initializers: vec![],
+		finalizers: vec![],
+	    },
+        ]
+    }
+}

--- a/src/actions/user/userproviders/none.rs
+++ b/src/actions/user/userproviders/none.rs
@@ -13,17 +13,15 @@ pub struct NoneUserProvider {}
 
 impl UserProvider for NoneUserProvider {
     fn add_user(&self, user: &UserVariant) -> Vec<Step> {
-        vec![
-            Step {
-		atom: Box::new(Exec {
-		    command: String::from("/bin/echo"),
-		    arguments: vec![String::from("Hello World")],
-		    privileged: false,
-		    ..Default::default()
-		}),
-		initializers: vec![],
-		finalizers: vec![],
-	    },
-        ]
+        vec![Step {
+            atom: Box::new(Exec {
+                command: String::from("/bin/echo"),
+                arguments: vec![String::from("Hello World")],
+                privileged: false,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }]
     }
 }


### PR DESCRIPTION
This will introduce some user management for comtrya, starting with the ability to add users. This follows the same sort of "provider" kind of mechanism as it packages work in comtrya since different operating systems will manage users in different ways. **Only** two providers are WIP as a reference implementation. A None provider for operating systems that do not have an implementation for a user provider and FreeBSD. 