### PR TITLE
feat: seperate package repository and install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = "0.3.11"
 walkdir = "2"
 which = "4.2.5"
 whoami = "1.2.1"
+sha256 = "1.0.3"
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11.0"

--- a/src/actions/package/install.rs
+++ b/src/actions/package/install.rs
@@ -37,12 +37,6 @@ impl Action for PackageInstall {
             atoms.append(&mut provider.bootstrap());
         }
 
-        if let Some(ref _repo) = variant.repository {
-            if !provider.has_repository(&variant) {
-                atoms.append(&mut provider.add_repository(&variant));
-            }
-        }
-
         atoms.append(&mut provider.install(&variant));
 
         span.exit();

--- a/src/actions/package/mod.rs
+++ b/src/actions/package/mod.rs
@@ -1,5 +1,6 @@
 pub mod install;
 pub mod providers;
+mod repository;
 
 use providers::PackageProviders;
 use serde::{Deserialize, Serialize};
@@ -40,12 +41,6 @@ pub struct PackageVariant {
     provider: PackageProviders,
 
     #[serde(default)]
-    repository: Option<String>,
-
-    #[serde(default)]
-    key: Option<String>,
-
-    #[serde(default)]
     extra_args: Vec<String>,
 }
 
@@ -71,8 +66,6 @@ impl From<&Package> for PackageVariant {
                 name: package.name.clone(),
                 list: package.list.clone(),
                 provider: package.provider.clone(),
-                repository: package.repository.clone(),
-                key: package.key.clone(),
                 extra_args: package.extra_args.clone(),
             };
         };
@@ -85,8 +78,6 @@ impl From<&Package> for PackageVariant {
             name: package.name.clone(),
             list: package.list.clone(),
             provider: variant.provider.clone(),
-            repository: variant.repository.clone(),
-            key: package.key.clone(),
             extra_args: variant.extra_args.clone(),
         };
 
@@ -96,14 +87,6 @@ impl From<&Package> for PackageVariant {
 
         if !variant.list.is_empty() {
             package.list = variant.list.clone();
-        }
-
-        if variant.repository.is_some() {
-            package.repository = variant.repository.clone();
-        };
-
-        if variant.key.is_some() {
-            package.key = variant.key.clone();
         }
 
         // I've been torn about this, but here's my logic.

--- a/src/actions/package/providers/bsdpkg.rs
+++ b/src/actions/package/providers/bsdpkg.rs
@@ -1,4 +1,5 @@
 use super::PackageProvider;
+use crate::actions::package::repository::PackageRepository;
 use crate::steps::finalizers::FlowControl::StopIf;
 use crate::steps::finalizers::OutputContains;
 use crate::steps::Step;
@@ -46,11 +47,11 @@ impl PackageProvider for BsdPkg {
         }]
     }
 
-    fn has_repository(&self, _package: &PackageVariant) -> bool {
+    fn has_repository(&self, _: &PackageRepository) -> bool {
         false
     }
 
-    fn add_repository(&self, _package: &PackageVariant) -> Vec<Step> {
+    fn add_repository(&self, _: &PackageRepository) -> Vec<Step> {
         vec![]
     }
 

--- a/src/actions/package/providers/mod.rs
+++ b/src/actions/package/providers/mod.rs
@@ -13,7 +13,7 @@ mod yay;
 use self::yay::Yay;
 mod winget;
 use self::winget::Winget;
-use super::PackageVariant;
+use super::{repository::PackageRepository, PackageVariant};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -92,8 +92,8 @@ pub trait PackageProvider {
     fn name(&self) -> &str;
     fn available(&self) -> bool;
     fn bootstrap(&self) -> Vec<Step>;
-    fn has_repository(&self, package: &PackageVariant) -> bool;
-    fn add_repository(&self, package: &PackageVariant) -> Vec<Step>;
+    fn has_repository(&self, package: &PackageRepository) -> bool;
+    fn add_repository(&self, package: &PackageRepository) -> Vec<Step>;
     fn query(&self, package: &PackageVariant) -> Vec<String>;
     fn install(&self, package: &PackageVariant) -> Vec<Step>;
 }

--- a/src/actions/package/providers/pkgin.rs
+++ b/src/actions/package/providers/pkgin.rs
@@ -1,4 +1,5 @@
 use super::PackageProvider;
+use crate::actions::package::repository::PackageRepository;
 use crate::steps::finalizers::FlowControl::StopIf;
 use crate::steps::finalizers::OutputContains;
 use crate::steps::Step;
@@ -32,11 +33,11 @@ impl PackageProvider for Pkgin {
         vec![]
     }
 
-    fn has_repository(&self, _package: &PackageVariant) -> bool {
+    fn has_repository(&self, _: &PackageRepository) -> bool {
         false
     }
 
-    fn add_repository(&self, _package: &PackageVariant) -> Vec<Step> {
+    fn add_repository(&self, _: &PackageRepository) -> Vec<Step> {
         vec![]
     }
 

--- a/src/actions/package/providers/winget.rs
+++ b/src/actions/package/providers/winget.rs
@@ -1,4 +1,5 @@
 use super::PackageProvider;
+use crate::actions::package::repository::PackageRepository;
 use crate::steps::Step;
 use crate::{actions::package::PackageVariant, atoms::command::Exec};
 use serde::{Deserialize, Serialize};
@@ -27,11 +28,11 @@ impl PackageProvider for Winget {
         vec![]
     }
 
-    fn has_repository(&self, _package: &PackageVariant) -> bool {
+    fn has_repository(&self, _: &PackageRepository) -> bool {
         true
     }
 
-    fn add_repository(&self, _package: &PackageVariant) -> Vec<Step> {
+    fn add_repository(&self, _: &PackageRepository) -> Vec<Step> {
         vec![]
     }
 

--- a/src/actions/package/providers/yay.rs
+++ b/src/actions/package/providers/yay.rs
@@ -1,4 +1,5 @@
 use super::PackageProvider;
+use crate::actions::package::repository::PackageRepository;
 use crate::actions::package::PackageVariant;
 use crate::atoms::command::Exec;
 use crate::steps::Step;
@@ -70,11 +71,11 @@ impl PackageProvider for Yay {
         ]
     }
 
-    fn has_repository(&self, _package: &PackageVariant) -> bool {
+    fn has_repository(&self, _: &PackageRepository) -> bool {
         false
     }
 
-    fn add_repository(&self, _package: &PackageVariant) -> Vec<Step> {
+    fn add_repository(&self, _: &PackageRepository) -> Vec<Step> {
         vec![]
     }
 

--- a/src/actions/package/repository.rs
+++ b/src/actions/package/repository.rs
@@ -1,0 +1,102 @@
+use crate::actions::Action;
+use crate::contexts::Contexts;
+use crate::manifests::Manifest;
+use crate::steps::Step;
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+use tracing::{error, span};
+
+use super::providers::PackageProviders;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PackageRepository {
+    #[serde(alias = "url")]
+    pub name: String,
+
+    pub key: Option<RepositoryKey>,
+
+    #[serde(default)]
+    pub provider: PackageProviders,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct RepositoryKey {
+    pub url: String,
+    pub name: Option<String>,
+    pub key: Option<String>,
+    pub fingerprint: Option<String>,
+}
+
+impl Action for PackageRepository {
+    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> Vec<Step> {
+        let box_provider = self.provider.clone().get_provider();
+        let provider = box_provider.deref();
+
+        let span = span!(
+            tracing::Level::INFO,
+            "package.repository",
+            provider = provider.name()
+        )
+        .entered();
+
+        let mut atoms: Vec<Step> = vec![];
+
+        // If the provider isn't available, see if we can bootstrap it
+        if !provider.available() {
+            if provider.bootstrap().is_empty() {
+                error!(
+                    "Package Provider, {}, isn't available. Skipping action",
+                    provider.name()
+                );
+                return vec![];
+            }
+
+            atoms.append(&mut provider.bootstrap());
+        }
+
+        if !provider.has_repository(&self) {
+            atoms.append(&mut provider.add_repository(&self));
+        }
+
+        span.exit();
+
+        atoms
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::actions::Actions;
+
+//     #[test]
+//     fn it_can_be_deserialized() {
+//         let yaml = r#"
+// - action: package.install
+//   name: curl
+
+// - action: package.install
+//   list:
+//     - bash
+// "#;
+
+//         let mut actions: Vec<Actions> = serde_yaml::from_str(yaml).unwrap();
+
+//         match actions.pop() {
+//             Some(Actions::PackageInstall(action)) => {
+//                 assert_eq!(vec!["bash"], action.action.list);
+//             }
+//             _ => {
+//                 panic!("PackageInstall didn't deserialize to the correct type");
+//             }
+//         };
+
+//         match actions.pop() {
+//             Some(Actions::PackageInstall(action)) => {
+//                 assert_eq!("curl", action.action.name.unwrap());
+//             }
+//             _ => {
+//                 panic!("PackageInstall didn't deserialize to the correct type");
+//             }
+//         };
+//     }
+// }


### PR DESCRIPTION
This PR seperates `PackageRepository` from `PackageInstall`.

Which means that this:

```yaml
actions:
  - action: package.install
    name: something
    repository: blah
```

Becomes:

```yaml
actions:
  - action: package.repository
    url: somewhere
    key:
      url: blah
      name: blah
  - action: package.install
    name: something
```

Closes #172 