### PR TITLE
 [#196][feat] add where condition to manifests

### DIFF
--- a/examples/where/main.yaml
+++ b/examples/where/main.yaml
@@ -1,0 +1,7 @@
+where: variables.fkbr == "sxoe" && variables.kuci == "xhpv"
+
+actions:
+  - action: command.run
+    command: echo
+    args:
+      - hello, world!

--- a/lib/src/actions/file/link.rs
+++ b/lib/src/actions/file/link.rs
@@ -184,6 +184,7 @@ mod tests {
         };
 
         let manifest: Manifest = Manifest {
+            r#where: None,
             root_dir: Some(source_dir.path().to_path_buf()),
             actions: vec![],
             depends: vec![],
@@ -238,6 +239,7 @@ mod tests {
         }
 
         let manifest: Manifest = Manifest {
+            r#where: None,
             root_dir: Some(source_dir.clone()),
             actions: vec![],
             depends: vec![],

--- a/lib/src/contexts/mod.rs
+++ b/lib/src/contexts/mod.rs
@@ -3,7 +3,7 @@ use rhai::Scope;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use std::collections::BTreeMap;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument, trace, warn};
 use user::UserContextProvider;
 
 use crate::{
@@ -106,6 +106,8 @@ pub fn to_rhai(context: &Contexts) -> rhai::Scope {
                 panic!("Failed to convert context value to dynamic: {}", error);
             }
         };
+
+        trace!("Add dynamic constant '{}' -> {}", &m, &dynamic);
 
         scope.push_constant(m.clone(), dynamic);
     });

--- a/lib/src/manifests/mod.rs
+++ b/lib/src/manifests/mod.rs
@@ -13,6 +13,9 @@ use tracing::error;
 #[derive(JsonSchema, Clone, Debug, Serialize, Deserialize)]
 pub struct Manifest {
     #[serde(default)]
+    pub r#where: Option<String>,
+
+    #[serde(default)]
     pub name: Option<String>,
 
     #[serde(default)]

--- a/tests/basic_usage.rs
+++ b/tests/basic_usage.rs
@@ -32,6 +32,18 @@ actions:
     to: mydircopy
 "#,
                 ),
+                f(
+                    "where_condition.yaml",
+                    r#"
+where: non.existing.variable == true
+
+actions:
+  - action: command.run
+    command: echo
+    args:
+      - hello, world!
+                    "#,
+                ),
             ],
         )],
     )


### PR DESCRIPTION
- use rhai scripts to use condition
  - if the rhai script resolves to true -> run manifest
  - if the rhai script fails or resolves to false -> don't run manifest
- context variables can be used

## I'm submitting a

- [ ] bug fix
- [x] feature

## What is the motivation / use case for changing the behavior?

If a manifest runs or not depends on the `dry run` option. Manifest execution can be fine tuned by adding `where` conditions.