### PR TITLE
Zypper support

### DIFF
--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -15,6 +15,8 @@ mod winget;
 use self::winget::Winget;
 mod xbps;
 use self::xbps::Xbps;
+mod zypper;
+use self::zypper::Zypper;
 use super::{repository::PackageRepository, PackageVariant};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -44,6 +46,9 @@ pub enum PackageProviders {
 
     #[serde(rename = "xbps")]
     Xbps,
+
+    #[serde(rename = "zypper")]
+    Zypper,
 }
 
 impl PackageProviders {
@@ -57,6 +62,7 @@ impl PackageProviders {
             PackageProviders::Yay => Box::new(Yay {}),
             PackageProviders::Winget => Box::new(Winget {}),
             PackageProviders::Xbps => Box::new(Xbps {}),
+            PackageProviders::Zypper => Box::new(Zypper {}),
         }
     }
 }
@@ -81,6 +87,9 @@ impl Default for PackageProviders {
             // For some reason, the Rust image is showing as this and
             // its Debian based?
             os_info::Type::OracleLinux => PackageProviders::Aptitude,
+            // OpenSUSE and SUSE
+            os_info::Type::openSUSE => PackageProviders::Zypper,
+            os_info::Type::SUSE => PackageProviders::Zypper,
             // Red-Hat Variants
             os_info::Type::Fedora => PackageProviders::Dnf,
             os_info::Type::Redhat => PackageProviders::Dnf,

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -18,7 +18,7 @@ impl PackageProvider for Zypper {
         match which("zypper") {
             Ok(_) => true,
             Err(_) => {
-                warn!(message = "zypper not availiable");
+                warn!(message = "zypper not available");
                 false
             }
         }

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -65,26 +65,6 @@ mod test {
 
     use super::*;
 
-    // These tests are really weak at the moment, but that's because I'm not
-    // sure how to add derive(Debug,Default) to struct Step
-    // TODO: Learn how to fix this
-
-    // #[test]
-    // fn test_add_repository_with_key_and_fingerprint() {
-    //     let aptitude = Aptitude {};
-    //     let steps = aptitude.add_repository(&PackageRepository {
-    //         name: String::from("test"),
-    //         key: Some(RepositoryKey {
-    //             url: String::from("abc"),
-    //             fingerprint: Some(String::from("abc")),
-    //             ..Default::default()
-    //         }),
-    //         ..Default::default()
-    //     });
-
-    //     assert_eq!(steps.len(), 3);
-    // }
-
     #[test]
     fn test_install() {
         let zypper = Zypper {};

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -3,7 +3,6 @@ use crate::actions::package::{repository::PackageRepository, PackageVariant};
 use crate::atoms::command::Exec;
 use crate::steps::Step;
 use serde::{Deserialize, Serialize};
-use sha256::digest;
 use tracing::warn;
 use which::which;
 

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -1,0 +1,100 @@
+use super::PackageProvider;
+use crate::actions::package::{repository::PackageRepository, PackageVariant};
+use crate::atoms::command::Exec;
+use crate::steps::Step;
+use serde::{Deserialize, Serialize};
+use sha256::digest;
+use tracing::warn;
+use which::which;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Zypper {}
+
+impl PackageProvider for Zypper {
+    fn name(&self) -> &str {
+        "Zypper"
+    }
+
+    fn available(&self) -> bool {
+        match which("zypper") {
+            Ok(_) => true,
+            Err(_) => {
+                warn!(message = "zypper not availiable");
+                false
+            }
+        }
+    }
+
+    fn bootstrap(&self) -> Vec<Step> {
+        vec![]
+    }
+
+    fn has_repository(&self, _: &PackageRepository) -> bool {
+        false
+    }
+
+    fn add_repository(&self, _repository: &PackageRepository) -> Vec<Step> {
+	vec![]
+    }
+
+    fn query(&self, package: &PackageVariant) -> Vec<String> {
+        package.packages()
+    }
+
+    fn install(&self, package: &PackageVariant) -> Vec<Step> {
+        vec![Step {
+            atom: Box::new(Exec {
+                command: String::from("zypper"),
+                arguments: vec![String::from("install"), String::from("-y")]
+                    .into_iter()
+                    .chain(package.extra_args.clone())
+                    .chain(package.packages())
+                    .collect(),
+                privileged: true,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::actions::package::{providers::PackageProviders};
+
+    use super::*;
+
+    // These tests are really weak at the moment, but that's because I'm not
+    // sure how to add derive(Debug,Default) to struct Step
+    // TODO: Learn how to fix this
+
+    // #[test]
+    // fn test_add_repository_with_key_and_fingerprint() {
+    //     let aptitude = Aptitude {};
+    //     let steps = aptitude.add_repository(&PackageRepository {
+    //         name: String::from("test"),
+    //         key: Some(RepositoryKey {
+    //             url: String::from("abc"),
+    //             fingerprint: Some(String::from("abc")),
+    //             ..Default::default()
+    //         }),
+    //         ..Default::default()
+    //     });
+
+    //     assert_eq!(steps.len(), 3);
+    // }
+
+    #[test]
+    fn test_install() {
+	    let zypper = Zypper {};
+	    let steps = zypper.install(&PackageVariant {
+            name: Some(String::from("")),
+            list: vec![],
+            extra_args: vec![],
+            provider: PackageProviders::Zypper,
+        });
+
+        assert_eq!(steps.len(), 1);
+    }
+}

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -34,7 +34,7 @@ impl PackageProvider for Zypper {
     }
 
     fn add_repository(&self, _repository: &PackageRepository) -> Vec<Step> {
-	vec![]
+        vec![]
     }
 
     fn query(&self, package: &PackageVariant) -> Vec<String> {
@@ -61,7 +61,7 @@ impl PackageProvider for Zypper {
 
 #[cfg(test)]
 mod test {
-    use crate::actions::package::{providers::PackageProviders};
+    use crate::actions::package::providers::PackageProviders;
 
     use super::*;
 
@@ -87,8 +87,8 @@ mod test {
 
     #[test]
     fn test_install() {
-	    let zypper = Zypper {};
-	    let steps = zypper.install(&PackageVariant {
+        let zypper = Zypper {};
+        let steps = zypper.install(&PackageVariant {
             name: Some(String::from("")),
             list: vec![],
             extra_args: vec![],


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [X] feature

## What is the current behaviour?

Current behavior, prior to code in PR, is no package support for Zypper.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Add support for Zypper on OpenSUSE and SUSE distributions. Allow the user to install packages with zypper through the use of comtrya.

## What is the motivation / use case for changing the behavior?

Feature request that was noticed.

## Please tell us about your environment:

OpenSUSE tumbleweed

Version (`comtrya --version`): comtrya 0.7.4
Operating system:
OpenSUSE Tumbleweed