### PR TITLE
fix(windows): adjust to canonical source path

### DIFF
--- a/lib/src/atoms/file/link.rs
+++ b/lib/src/atoms/file/link.rs
@@ -55,8 +55,11 @@ impl Atom for Link {
             }
         };
 
+        const PREFIX: &str = r#"\\?\"#;
+        let source = PathBuf::from(&self.source.to_str().unwrap().replace(PREFIX, ""));
+
         // If this file doesn't link to what we expect, lets make it so
-        !link.eq(&self.source)
+        !link.eq(&source)
     }
 
     #[cfg(unix)]

--- a/lib/src/atoms/file/link.rs
+++ b/lib/src/atoms/file/link.rs
@@ -55,8 +55,12 @@ impl Atom for Link {
             }
         };
 
-        const PREFIX: &str = r#"\\?\"#;
-        let source = PathBuf::from(&self.source.to_str().unwrap().replace(PREFIX, ""));
+        let source = if cfg!(target_os = "windows") {
+            const PREFIX: &str = r#"\\?\"#;
+            PathBuf::from(&self.source.display().to_string().replace(PREFIX, ""))
+        } else {
+            self.source.to_owned()
+        };
 
         // If this file doesn't link to what we expect, lets make it so
         !link.eq(&source)


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

source path: `\\?\C:\Users\kecrily\Desktop\dev\per\dotfiles\modules\node\files\.npmrc`

link: `C:\Users\kecrily\Desktop\dev\per\dotfiles\modules\node\files\.npmrc`

So https://github.com/comtrya/comtrya/blob/c4705ca646c89912442ed9bd8e1564f7015c73ee/lib/src/atoms/file/link.rs#L59

will always be `true`.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

A link action was executed before, and then an error occurs when it is executed again.

## What is the expected behavior?

`source` is canonical.

## What is the motivation / use case for changing the behavior?

Make the file.link action available on Windows.

## Please tell us about your environment:

Version (`comtrya --version`): comtrya 0.7.4
Operating system: Windows 11 Dev Preview
