### PR TITLE
[ci] fix build matrix and stick to macOS 12 only

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,9 +71,6 @@ jobs:
           - { os: ubuntu-20.04, target: aarch64-unknown-linux-gnu }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
 
-          - { os: macos-11, target: x86_64-apple-darwin }
-          - { os: macos-11, target: aarch64-apple-darwin }
-
           - { os: macos-12, target: x86_64-apple-darwin }
           - { os: macos-12, target: aarch64-apple-darwin }
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -68,7 +68,7 @@ jobs:
           #     target: x86_64-unknown-linux-musl,
           #     use-cross: true,
           #   }
-          - { os: macos-11, target: x86_64-apple-darwin }
+          - { os: macos-12, target: x86_64-apple-darwin }
           - { os: windows-2019, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?
macOS 11 and macOS 12 fight for the releasing artifact. So we just stick with macOS 12 builds, which should representative enough for the macOS world.