### PR TITLE
Initial support for Macports

### DIFF
--- a/lib/src/actions/package/providers/macports.rs
+++ b/lib/src/actions/package/providers/macports.rs
@@ -1,0 +1,75 @@
+use super::PackageProvider;
+use crate::actions::package::repository::PackageRepository;
+use crate::atoms::directory::Create;
+use crate::atoms::git::Clone;
+use crate::steps::Step;
+use crate::{actions::package::PackageVariant, atoms::command::Exec};
+use serde::{Deserialize, Serialize};
+use std::{path::Path, process::Command};
+use tracing::{debug, trace, warn};
+use which::which;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Macports {}
+
+impl PackageProvider for Macports {
+    fn name(&self) -> &str {
+        "MacPorts"
+    }
+
+    fn available(&self) -> bool {
+        match which("port") {
+            Ok(_) => true,
+            Err(_) => {
+                warn!(message = "MacPorts not available, check if in $PATH");
+                false
+            }
+        }
+    }
+
+    fn bootstrap(&self) -> Vec<Step> {
+        vec![]
+    }
+
+    fn has_repository(&self, _: &PackageRepository) -> bool {
+        // Brew doesn't make it easy to check if the repository is already added
+        // except by running `brew tap` and grepping.
+        // Fortunately, adding an exist tap is pretty fast.
+        false
+    }
+
+    fn add_repository(&self, _repository: &PackageRepository) -> Vec<Step> {
+        vec![]
+    }
+
+    fn query(&self, _package: &PackageVariant) -> Vec<String> {
+        vec![]
+    }
+
+    fn install(&self, package: &PackageVariant) -> Vec<Step> {
+        let cli = match which("port") {
+            Ok(c) => c,
+            Err(_) => {
+                warn!(message = "MacPorts is not availiable.");
+                return vec![];
+            }
+        };
+
+        vec![
+            Step {
+                atom: Box::new(Exec {
+                    command: String::from(cli.to_str().unwrap()),
+                    arguments: vec![String::from("install")]
+                        .into_iter()
+                        .chain(package.extra_args.clone())
+                        .chain(package.packages())
+                        .collect(),
+                    privileged: true,
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            }
+        ]
+    }
+}

--- a/lib/src/actions/package/providers/macports.rs
+++ b/lib/src/actions/package/providers/macports.rs
@@ -1,12 +1,9 @@
 use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
-use crate::atoms::directory::Create;
-use crate::atoms::git::Clone;
 use crate::steps::Step;
 use crate::{actions::package::PackageVariant, atoms::command::Exec};
 use serde::{Deserialize, Serialize};
-use std::{path::Path, process::Command};
-use tracing::{debug, trace, warn};
+use tracing::warn;
 use which::which;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/lib/src/actions/package/providers/macports.rs
+++ b/lib/src/actions/package/providers/macports.rs
@@ -55,21 +55,19 @@ impl PackageProvider for Macports {
             }
         };
 
-        vec![
-            Step {
-                atom: Box::new(Exec {
-                    command: String::from(cli.to_str().unwrap()),
-                    arguments: vec![String::from("install")]
-                        .into_iter()
-                        .chain(package.extra_args.clone())
-                        .chain(package.packages())
-                        .collect(),
-                    privileged: true,
-                    ..Default::default()
-                }),
-                initializers: vec![],
-                finalizers: vec![],
-            }
-        ]
+        vec![Step {
+            atom: Box::new(Exec {
+                command: String::from(cli.to_str().unwrap()),
+                arguments: vec![String::from("install")]
+                    .into_iter()
+                    .chain(package.extra_args.clone())
+                    .chain(package.packages())
+                    .collect(),
+                privileged: true,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }]
     }
 }

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -7,6 +7,8 @@ mod dnf;
 use self::dnf::Dnf;
 mod homebrew;
 use self::homebrew::Homebrew;
+mod macports;
+use self::macports::Macports;
 mod pkgin;
 use self::pkgin::Pkgin;
 mod yay;
@@ -35,6 +37,9 @@ pub enum PackageProviders {
     #[serde(rename = "homebrew", alias = "brew")]
     Homebrew,
 
+    #[serde(rename = "macports", alias = "port")]
+    Macports,
+
     #[serde(rename = "pkgin")]
     Pkgin,
 
@@ -58,6 +63,7 @@ impl PackageProviders {
             PackageProviders::BsdPkg => Box::new(BsdPkg {}),
             PackageProviders::Dnf => Box::new(Dnf {}),
             PackageProviders::Homebrew => Box::new(Homebrew {}),
+            PackageProviders::Macports => Box::new(Macports {}),
             PackageProviders::Pkgin => Box::new(Pkgin {}),
             PackageProviders::Yay => Box::new(Yay {}),
             PackageProviders::Winget => Box::new(Winget {}),


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [X] feature
- [ ] documentation addition

## What is the current behaviour?

No support for macports package manager.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Allow installing software with macports.

## What is the motivation / use case for changing the behavior?

Feature request for MacPorts support as per issue #191 

## Please tell us about your environment:

Version (`comtrya --version`): comtrya 0.7.4
Operating system: Mac Os 

---

# Other things to note for PR.

This is a feature request from @theowenyoung. Would like some input on this. Right now the implementation assume that macports is installed and it's binary is in $PATH. 

Would like to provide the bootstrap functionality in a separate PR, how that is handled can be talked about in the issue.

## For the reviewer

There are some clippy warnings regarding unused imports. I do intend to make use of these as I play around with the bootstrap process. I can remove them for this PR is needed.

