### PR TITLE
refactor: add more descriptive error message to file resolution

### DIFF
--- a/lib/src/actions/file/mod.rs
+++ b/lib/src/actions/file/mod.rs
@@ -18,6 +18,14 @@ pub trait FileAction: Action {
             .join("files")
             .join(path)
             .normalize()
+            .map_err(|e| {
+                anyhow!(
+                    "Resolution of {} failed in manifest {} because {}",
+                    path.to_string(),
+                    manifest.name.as_ref().unwrap(),
+                    e.to_string()
+                )
+            })
             .unwrap()
             .as_path()
             .to_path_buf()


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [ x] documentation addition

## What is the current behaviour?
When a file is not found or file resolution fails due to some other error, the error message received is not very descriptive of what file caused the problem. See #198 for an example of the error. Closes #199 .

## What is the expected behavior?
The error message should assist the user in solving the problem by displaying what path caused the issue and what manifest the file was pulled from.

## What is the motivation / use case for changing the behavior?
To provide a better UX when/if something goes wrong.

## Please tell us about your environment:

Operating system: Windows 11, WSL2 running Ubuntu 20.04
