### PR TITLE
[fix] documentation about installing nextest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for reading this document!
 - Cargo (with `fmt`, `clippy` and `nextest`):
   - `rustup component add rustfmt`
   - `rustup component add clippy`
-  - `cargo install nextest`
+  - `cargo install cargo-nextest`
 
 ## Code style
 Before you create a PR, just run `check.sh`:


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

## What is the current behaviour?
> installation instructions of `nextest` are wrong

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
> nothing to tell here

## What is the expected behavior?
> nothing to tell here

## What is the motivation / use case for changing the behavior?
> nothing to tell here

## Please tell us about your environment:
> nothing to tell here