### PR TITLE
Feature: Adding users to groups outside of user creation

### DIFF
--- a/examples/user/user.yaml
+++ b/examples/user/user.yaml
@@ -1,0 +1,10 @@
+actions:
+  - action: user.add
+    fullname: testuser
+    home_dir: /home/test
+    username: test
+    shell: sh
+  - action: user.group
+    username: testuser
+    group:
+      - wheel

--- a/lib/src/actions/mod.rs
+++ b/lib/src/actions/mod.rs
@@ -161,7 +161,7 @@ impl Actions {
             Actions::PackageInstall(a) => a,
             Actions::PackageRepository(a) => a,
             Actions::UserAdd(a) => a,
-	    Actions::UserAddGroup(a) => a,
+            Actions::UserAddGroup(a) => a,
         }
     }
 }
@@ -182,7 +182,7 @@ impl Display for Actions {
             Actions::PackageInstall(_) => "package.install",
             Actions::PackageRepository(_) => "package.repository",
             Actions::UserAdd(_) => "user.add",
-	    Actions::UserAddGroup(_) => "user.group",
+            Actions::UserAddGroup(_) => "user.group",
         };
 
         write!(f, "{}", name)

--- a/lib/src/actions/mod.rs
+++ b/lib/src/actions/mod.rs
@@ -29,6 +29,8 @@ use std::fmt::Display;
 use tracing::error;
 use user::add::UserAdd;
 
+use self::user::add_group::UserAddGroup;
+
 #[derive(JsonSchema, Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ConditionalVariantAction<T> {
     #[serde(flatten)]
@@ -138,6 +140,9 @@ pub enum Actions {
 
     #[serde(rename = "user.add")]
     UserAdd(ConditionalVariantAction<UserAdd>),
+
+    #[serde(rename = "user.group")]
+    UserAddGroup(ConditionalVariantAction<UserAddGroup>),
 }
 
 impl Actions {
@@ -156,6 +161,7 @@ impl Actions {
             Actions::PackageInstall(a) => a,
             Actions::PackageRepository(a) => a,
             Actions::UserAdd(a) => a,
+	    Actions::UserAddGroup(a) => a,
         }
     }
 }
@@ -176,6 +182,7 @@ impl Display for Actions {
             Actions::PackageInstall(_) => "package.install",
             Actions::PackageRepository(_) => "package.repository",
             Actions::UserAdd(_) => "user.add",
+	    Actions::UserAddGroup(_) => "user.group",
         };
 
         write!(f, "{}", name)

--- a/lib/src/actions/user/add_group.rs
+++ b/lib/src/actions/user/add_group.rs
@@ -1,0 +1,34 @@
+use super::providers::UserProviders;
+use crate::actions::Action;
+use crate::contexts::Contexts;
+use crate::manifests::Manifest;
+use crate::steps::Step;
+use std::ops::Deref;
+use serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
+
+// pub type UserAddGroup = User;
+#[derive(JsonSchema, Clone, Debug, Default, Serialize, Deserialize)]
+pub struct UserAddGroup {
+    #[serde(default)]
+    pub username: String,
+
+    #[serde(default)]
+    pub group: Vec<String>,
+
+    #[serde(default)]
+    pub provider: UserProviders,
+}
+
+impl Action for UserAddGroup {
+    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+        let box_provider = self.provider.clone().get_provider();
+        let provider = box_provider.deref();
+
+        let mut atoms: Vec<Step> = vec![];
+
+        atoms.append(&mut provider.add_to_group(&self));
+
+        Ok(atoms)
+    }
+}

--- a/lib/src/actions/user/add_group.rs
+++ b/lib/src/actions/user/add_group.rs
@@ -3,9 +3,9 @@ use crate::actions::Action;
 use crate::contexts::Contexts;
 use crate::manifests::Manifest;
 use crate::steps::Step;
-use std::ops::Deref;
-use serde::{Deserialize, Serialize};
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 
 // pub type UserAddGroup = User;
 #[derive(JsonSchema, Clone, Debug, Default, Serialize, Deserialize)]

--- a/lib/src/actions/user/mod.rs
+++ b/lib/src/actions/user/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod add_group;
 pub mod providers;
 
 use providers::UserProviders;

--- a/lib/src/actions/user/providers/freebsd.rs
+++ b/lib/src/actions/user/providers/freebsd.rs
@@ -1,7 +1,7 @@
 use super::UserProvider;
-use crate::steps::Step;
-use crate::atoms::command::Exec;
 use crate::actions::user::{add_group::UserAddGroup, UserVariant};
+use crate::atoms::command::Exec;
+use crate::steps::Step;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 

--- a/lib/src/actions/user/providers/freebsd.rs
+++ b/lib/src/actions/user/providers/freebsd.rs
@@ -1,6 +1,7 @@
 use super::UserProvider;
 use crate::steps::Step;
-use crate::{actions::user::UserVariant, atoms::command::Exec};
+use crate::atoms::command::Exec;
+use crate::actions::user::{add_group::UserAddGroup, UserVariant};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -54,7 +55,7 @@ impl UserProvider for FreeBSDUserProvider {
         }]
     }
 
-    fn add_to_group(&self, _user: &UserVariant) -> Vec<Step> {
+    fn add_to_group(&self, _user: &UserAddGroup) -> Vec<Step> {
         warn!(message = "Functionality not implemented for platform");
         vec![]
     }

--- a/lib/src/actions/user/providers/linux.rs
+++ b/lib/src/actions/user/providers/linux.rs
@@ -1,6 +1,8 @@
 use super::UserProvider;
 use crate::steps::Step;
-use crate::{actions::user::add_group::UserAddGroup, actions::user::UserVariant, atoms::command::Exec};
+use crate::{
+    actions::user::add_group::UserAddGroup, actions::user::UserVariant, atoms::command::Exec,
+};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use which::which;
@@ -55,11 +57,11 @@ impl UserProvider for LinuxUserProvider {
         }];
 
         if !user.group.is_empty() {
-	    let user_groups = UserAddGroup {
-		username: user.username.clone(),
-		group: user.group.clone(),
-		provider: user.provider.clone(),
-	    };
+            let user_groups = UserAddGroup {
+                username: user.username.clone(),
+                group: user.group.clone(),
+                provider: user.provider.clone(),
+            };
             for group in self.add_to_group(&user_groups) {
                 steps.push(group);
             }

--- a/lib/src/actions/user/providers/linux.rs
+++ b/lib/src/actions/user/providers/linux.rs
@@ -1,6 +1,6 @@
 use super::UserProvider;
 use crate::steps::Step;
-use crate::{actions::user::UserVariant, atoms::command::Exec};
+use crate::{actions::user::add_group::UserAddGroup, actions::user::UserVariant, atoms::command::Exec};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use which::which;
@@ -55,7 +55,12 @@ impl UserProvider for LinuxUserProvider {
         }];
 
         if !user.group.is_empty() {
-            for group in self.add_to_group(user) {
+	    let user_groups = UserAddGroup {
+		username: user.username.clone(),
+		group: user.group.clone(),
+		provider: user.provider.clone(),
+	    };
+            for group in self.add_to_group(&user_groups) {
                 steps.push(group);
             }
         }
@@ -63,7 +68,7 @@ impl UserProvider for LinuxUserProvider {
         steps
     }
 
-    fn add_to_group(&self, user: &UserVariant) -> Vec<Step> {
+    fn add_to_group(&self, user: &UserAddGroup) -> Vec<Step> {
         let cli = match which("usermod") {
             Ok(c) => c,
             Err(_) => {
@@ -105,7 +110,7 @@ impl UserProvider for LinuxUserProvider {
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{LinuxUserProvider, UserProvider};
-    use crate::actions::user::UserVariant;
+    use crate::actions::user::{add_group::UserAddGroup, UserVariant};
 
     #[test]
     fn test_add_user() {
@@ -140,11 +145,8 @@ mod test {
     #[test]
     fn test_add_to_group() {
         let user_provider = LinuxUserProvider {};
-        let steps = user_provider.add_to_group(&UserVariant {
+        let steps = user_provider.add_to_group(&UserAddGroup {
             username: String::from("test"),
-            shell: String::from("sh"),
-            home_dir: String::from("/home/test"),
-            fullname: String::from("Test User"),
             group: vec![String::from("testgroup"), String::from("wheel")],
             ..Default::default()
         });

--- a/lib/src/actions/user/providers/mod.rs
+++ b/lib/src/actions/user/providers/mod.rs
@@ -3,7 +3,7 @@ use self::freebsd::FreeBSDUserProvider;
 use crate::steps::Step;
 mod none;
 use self::none::NoneUserProvider;
-use super::UserVariant;
+use super::{add_group::UserAddGroup, UserVariant};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 mod linux;
@@ -51,5 +51,5 @@ impl Default for UserProviders {
 
 pub trait UserProvider {
     fn add_user(&self, user: &UserVariant) -> Vec<Step>;
-    fn add_to_group(&self, user: &UserVariant) -> Vec<Step>;
+    fn add_to_group(&self, user: &UserAddGroup) -> Vec<Step>;
 }

--- a/lib/src/actions/user/providers/none.rs
+++ b/lib/src/actions/user/providers/none.rs
@@ -1,5 +1,5 @@
 use super::UserProvider;
-use crate::actions::user::UserVariant;
+use crate::actions::user::{add_group::UserAddGroup, UserVariant};
 use crate::steps::Step;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -13,7 +13,7 @@ impl UserProvider for NoneUserProvider {
         vec![]
     }
 
-    fn add_to_group(&self, _user: &UserVariant) -> Vec<Step> {
+    fn add_to_group(&self, _user: &UserAddGroup) -> Vec<Step> {
         warn!(message = "This system does not have a provider for users");
         vec![]
     }


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

Adding users to groups currently has to happen during the user creation step.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Exposes an action a user can use to add a user to a group outside of the user creation step.

## What is the motivation / use case for changing the behavior?

Allow for improved user management

## Please tell us about your environment:

Version (`comtrya --version`): Dev
Operating system: Fedora 36
