### PR TITLE
fix: ensure all actions in a manifest run

### DIFF
--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -192,7 +192,7 @@ pub(crate) fn execute(args: &Apply, runtime: &Runtime) -> anyhow::Result<()> {
                 if steps.peek().is_none() {
                     info!("nothing to be done to reconcile action");
                     span_action.exit();
-                    return;
+                    continue;
                 }
 
                 for mut step in steps {


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Comtrya stops as soon as an action returns an empty plan, meaning no further actions run.

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
