### PR TITLE
windows doesn't have "ls" on the path so make a test for windows that…

### DIFF
--- a/lib/src/steps/initializers/command_found.rs
+++ b/lib/src/steps/initializers/command_found.rs
@@ -23,6 +23,17 @@ mod tests {
         assert_eq!(false, result.unwrap());
     }
 
+    #[cfg(target_family = "windows")]
+    #[test]
+    fn it_returns_true_when_found() {
+        let initializer = CommandFound("cmd.exe");
+        let result = initializer.initialize();
+
+        assert_eq!(true, result.is_ok());
+        assert_eq!(true, result.unwrap());
+    }
+
+    #[cfg(target_family = "unix")]
     #[test]
     fn it_returns_true_when_found() {
         let initializer = CommandFound("ls");


### PR DESCRIPTION
… tests for a command in the path

## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

it_returns_true_when_found test fails

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

The test passes

## What is the motivation / use case for changing the behavior?

All tests should pass. The current tests looks for "ls" which isn't on window's path as an executable. This create a conditional compilation for the test such that the test that looks for "ls" is used on unix/unixy systems and there is a similar test compile for windows.

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.0
Operating system: Windows 11
