### PR TITLE
Windows directory copy

### DIFF
--- a/lib/src/actions/directory/copy.rs
+++ b/lib/src/actions/directory/copy.rs
@@ -16,6 +16,35 @@ impl DirectoryCopy {}
 
 impl DirectoryAction for DirectoryCopy {}
 
+#[cfg(target_family = "windows")]
+impl Action for DirectoryCopy {
+    fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+        let from: String = self.resolve(manifest, &self.from).display().to_string();
+
+        Ok(vec![
+            // Step {
+            //     atom: Box::new(Exec {
+            //         command: String::from("cmd /C mkdir"),
+            //         arguments: vec![self.to.clone()],
+            //         ..Default::default()
+            //     }),
+            //     initializers: vec![],
+            //     finalizers: vec![],
+            // },
+            Step {
+                atom: Box::new(Exec {
+                    command: String::from("Xcopy"),
+                    arguments: vec!["/E".to_string(), "/I".to_string(), from, self.to.clone()],
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            },
+        ])
+    }
+}
+
+#[cfg(target_family = "unix")]
 impl Action for DirectoryCopy {
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: String = self.resolve(manifest, &self.from).display().to_string();

--- a/lib/src/actions/directory/copy.rs
+++ b/lib/src/actions/directory/copy.rs
@@ -21,17 +21,7 @@ impl Action for DirectoryCopy {
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: String = self.resolve(manifest, &self.from).display().to_string();
 
-        Ok(vec![
-            // Step {
-            //     atom: Box::new(Exec {
-            //         command: String::from("cmd /C mkdir"),
-            //         arguments: vec![self.to.clone()],
-            //         ..Default::default()
-            //     }),
-            //     initializers: vec![],
-            //     finalizers: vec![],
-            // },
-            Step {
+        Ok(vec![ Step {
                 atom: Box::new(Exec {
                     command: String::from("Xcopy"),
                     arguments: vec!["/E".to_string(), "/I".to_string(), from, self.to.clone()],

--- a/lib/src/actions/directory/copy.rs
+++ b/lib/src/actions/directory/copy.rs
@@ -21,16 +21,15 @@ impl Action for DirectoryCopy {
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: String = self.resolve(manifest, &self.from).display().to_string();
 
-        Ok(vec![ Step {
-                atom: Box::new(Exec {
-                    command: String::from("Xcopy"),
-                    arguments: vec!["/E".to_string(), "/I".to_string(), from, self.to.clone()],
-                    ..Default::default()
-                }),
-                initializers: vec![],
-                finalizers: vec![],
-            },
-        ])
+        Ok(vec![Step {
+            atom: Box::new(Exec {
+                command: String::from("Xcopy"),
+                arguments: vec!["/E".to_string(), "/I".to_string(), from, self.to.clone()],
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }])
     }
 }
 

--- a/lib/src/steps/initializers/command_found.rs
+++ b/lib/src/steps/initializers/command_found.rs
@@ -23,6 +23,17 @@ mod tests {
         assert_eq!(false, result.unwrap());
     }
 
+    #[cfg(target_family = "windows")]
+    #[test]
+    fn it_returns_true_when_found() {
+        let initializer = CommandFound("cmd.exe");
+        let result = initializer.initialize();
+
+        assert_eq!(true, result.is_ok());
+        assert_eq!(true, result.unwrap());
+    }
+
+    #[cfg(target_family = "unix")]
     #[test]
     fn it_returns_true_when_found() {
         let initializer = CommandFound("ls");

--- a/lib/src/steps/initializers/command_found.rs
+++ b/lib/src/steps/initializers/command_found.rs
@@ -33,6 +33,16 @@ mod tests {
         assert_eq!(true, result.unwrap());
     }
 
+    #[cfg(target_family = "windows")]
+    #[test]
+    fn return_true_windows_xcopy() {
+        let initializer = CommandFound("Xcopy");
+        let result = initializer.initialize();
+
+        assert_eq!(true, result.is_ok());
+        assert_eq!(true, result.unwrap());
+    }
+
     #[cfg(target_family = "unix")]
     #[test]
     fn it_returns_true_when_found() {


### PR DESCRIPTION
## I'm submitting a

- [X] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Directories fail to copy on windows

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

Run a directory copy manifest on windows

#275 

## What is the expected behavior?

Be able to have a manifest copy a directory

## What is the motivation / use case for changing the behavior?

Fix broken functionality

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.0
Operating system: Windows 11
