### PR TITLE
Modify flags during install run for Winget

### DIFF
--- a/lib/src/actions/package/providers/winget.rs
+++ b/lib/src/actions/package/providers/winget.rs
@@ -49,7 +49,14 @@ impl PackageProvider for Winget {
                 atom: Box::new(Exec {
                     command: String::from("winget"),
                     arguments: [
-                        vec![String::from("install"), String::from("--silent")],
+                        vec![
+                            "install".to_string(),
+                            "--silent".to_string(),
+                            "--accept-package-agreements".to_string(),
+                            "--accept-source-agreements".to_string(),
+                            "--source".to_string(),
+                            "winget".to_string()
+                        ],
                         package.extra_args.clone(),
                         vec![p.clone()],
                     ]

--- a/lib/src/actions/package/providers/winget.rs
+++ b/lib/src/actions/package/providers/winget.rs
@@ -55,7 +55,7 @@ impl PackageProvider for Winget {
                             "--accept-package-agreements".to_string(),
                             "--accept-source-agreements".to_string(),
                             "--source".to_string(),
-                            "winget".to_string()
+                            "winget".to_string(),
                         ],
                         package.extra_args.clone(),
                         vec![p.clone()],

--- a/lib/src/steps/initializers/command_found.rs
+++ b/lib/src/steps/initializers/command_found.rs
@@ -32,7 +32,7 @@ mod tests {
         assert_eq!(true, result.is_ok());
         assert_eq!(true, result.unwrap());
     }
-    
+
     #[cfg(target_family = "windows")]
     #[test]
     fn return_true_windows_xcopy() {


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Issues outlined in #277 

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Use winget to install software

## What is the motivation / use case for changing the behavior?

Bug report in issues #277 

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.0
Operating system: Windows 11
