### PR TITLE
Initial implementation for supporting toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "comtrya"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "age",
  "anyhow",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "comtrya-lib"
-version = "0.7.4"
+version = "0.8.2"
 dependencies = [
  "age",
  "anyhow",
@@ -3651,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]

--- a/examples/toml-examples/command/command.toml
+++ b/examples/toml-examples/command/command.toml
@@ -1,0 +1,4 @@
+[[actions]]
+action = "command.run"
+command = "echo"
+args = [ "hi" ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -41,7 +41,7 @@ whoami = "1.2.1"
 sha256 = "1.0.3"
 schemars = "0.8.10"
 trust-dns-resolver = "0.22.0"
-toml = "0.5.9"
+toml = "0.5.10"
 octocrab = "0.17.0"
 openssl = { version = "0", features = ["vendored"] }
 

--- a/lib/src/manifests/load.rs
+++ b/lib/src/manifests/load.rs
@@ -100,17 +100,18 @@ pub fn load(manifest_path: PathBuf, contexts: &Contexts) -> HashMap<String, Mani
                     }
                 };
 
-		if let Some(mut manifest) = manifest {
-		    let name = get_manifest_name(&manifest_path, &entry).expect("Failed to get manifest name");
+                if let Some(mut manifest) = manifest {
+                    let name = get_manifest_name(&manifest_path, &entry)
+                        .expect("Failed to get manifest name");
 
-		    manifest.root_dir = entry.parent().map(|parent| parent.to_path_buf());
+                    manifest.root_dir = entry.parent().map(|parent| parent.to_path_buf());
 
-		    manifest.name = Some(name.clone());
+                    manifest.name = Some(name.clone());
 
-		    manifests.insert(name, manifest);
-		} else {
-		    error!("Unrecognized file extension for manifest");
-		}
+                    manifests.insert(name, manifest);
+                } else {
+                    error!("Unrecognized file extension for manifest");
+                }
 
                 span.exit();
             }

--- a/lib/src/manifests/load.rs
+++ b/lib/src/manifests/load.rs
@@ -87,9 +87,7 @@ pub fn load(manifest_path: PathBuf, contexts: &Contexts) -> HashMap<String, Mani
                     }
                 };
 
-                let manifest: Option<Manifest>;
-
-                manifest = match entry.extension().and_then(OsStr::to_str) {
+                let manifest: Option<Manifest> = match entry.extension().and_then(OsStr::to_str) {
                     Some("yaml") | Some("yml") => serde_yaml::from_str(template.deref()).ok(),
                     Some("toml") => toml::from_str(template.deref()).ok(),
                     _ => {


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [X] feature
- [ ] documentation addition

## What is the current behaviour?

Comtrya only support manifest files written in yaml.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Comtrya will be able to support manifests written in toml

## What is the motivation / use case for changing the behavior?

Request in #285 

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.2
Operating system: Fedora 37
