### PR TITLE
Add packaging status to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 [![GitHub Actions Status](https://img.shields.io/github/workflow/status/comtrya/comtrya/release/main?style=for-the-badge)](https://github.com/comtrya/comtrya/actions/workflows/main.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/comtrya/comtrya?style=for-the-badge)](https://codecov.io/gh/comtrya/comtrya)
 
-[
-![Discord](https://img.shields.io/discord/730728064031653999?label=Discord&style=for-the-badge)](https://rawkode.chat)
+[![Discord](https://img.shields.io/discord/730728064031653999?label=Discord&style=for-the-badge)](https://rawkode.chat)
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/comtrya.svg)](https://repology.org/metapackage/comtrya)
 
 ---
 


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

## What is the current behaviour?

README.md includes several badges but none about packaging.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Include badge about packaging.

## What is the motivation / use case for changing the behavior?

Keeping track of this form of adoption of Comtrya and showing potential users how they can install it other than from source or fetch script. (It's a bit weird, though, that the latest release on GH is reported to be 0.8.1 while on crates.io it's 0.8.2! Looks like it was only tagged but no release made?)

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
