### PR TITLE
fix: manifest_paths example and local dependencies

### DIFF
--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -75,7 +75,7 @@ pub(crate) fn execute(args: &Apply, runtime: &Runtime) -> anyhow::Result<()> {
 
     for (name, manifest) in manifests.iter() {
         manifest.depends.iter().for_each(|dependency| {
-            let (local_dependency_prefix, _) = name.rsplit_once(".").unwrap_or(("", ""));
+            let (local_dependency_prefix, _) = name.rsplit_once('.').unwrap_or(("", ""));
 
             let resolved_dependency_name =
                 dependency.replace("./", format!("{}.", local_dependency_prefix).as_str());

--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -75,12 +75,17 @@ pub(crate) fn execute(args: &Apply, runtime: &Runtime) -> anyhow::Result<()> {
 
     for (name, manifest) in manifests.iter() {
         manifest.depends.iter().for_each(|dependency| {
-            let m1 = match manifests.get(dependency) {
+            let (local_dependency_prefix, _) = name.rsplit_once(".").unwrap_or(("", ""));
+
+            let resolved_dependency_name =
+                dependency.replace("./", format!("{}.", local_dependency_prefix).as_str());
+
+            let m1 = match manifests.get(&resolved_dependency_name) {
                 Some(manifest) => manifest,
                 None => {
                     error!(
                         message = "Unresolved dependency",
-                        dependency = dependency.as_str()
+                        dependency = resolved_dependency_name.as_str()
                     );
 
                     return;

--- a/examples/Comtrya.yaml
+++ b/examples/Comtrya.yaml
@@ -2,8 +2,10 @@
 # Default: [.]
 # This is a list because we'll eventually support multiple.
 # However, only the first is used atm.
-manifests:
-  - https://github.com/rawkode/rawkode
+manifest_paths:
+  - .
+  # We also support Git repositories, using Docker's syntax:
+  #   https://docs.docker.com/build/building/context/#git-repositories
 
 # Used by the variables context provider:
 # context="variables" key="<key>" value="<value>"
@@ -12,4 +14,4 @@ variables:
   kuci: "xhpv"
 
 include_variables:
- - "dns+txt://comtrya.icepuma.dev"
+  - "dns+txt://comtrya.icepuma.dev"

--- a/examples/group/add_to_group.yaml
+++ b/examples/group/add_to_group.yaml
@@ -1,5 +1,5 @@
 depends:
-  - group
+  - ./group
 
 actions:
   - action: user.add
@@ -7,6 +7,5 @@ actions:
     home_dir: /home/test
     username: test
     shell: sh
-    group: 
+    group:
       - testgroup
-


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

The examples showed the `manifest_path` configuration incorrectly as `manifests`.

We also didn't support local dependency resolution. I know this shouldn't be the same PR, but I got carried away debugging.

Closes #278 