### PR TITLE
Add users to group and add groups

### DIFF
--- a/lib/src/actions/group/providers/macos.rs
+++ b/lib/src/actions/group/providers/macos.rs
@@ -23,14 +23,13 @@ impl GroupProvider for MacOsGroupProvider {
             return vec![];
         }
 
-	let mut group_creation_string = String::from("/Groups/");
+        let mut group_creation_string = String::from("/Groups/");
         group_creation_string.push_str(group.group_name.clone().as_str());
 
-	let mut args: Vec<String> = vec![];
-	args.push(".".to_string());
-	args.push("create".to_string());
-	args.push(group_creation_string.to_owned());
-	
+        let mut args: Vec<String> = vec![];
+        args.push(".".to_string());
+        args.push("create".to_string());
+        args.push(group_creation_string.to_owned());
 
         vec![Step {
             atom: Box::new(Exec {

--- a/lib/src/actions/group/providers/macos.rs
+++ b/lib/src/actions/group/providers/macos.rs
@@ -1,0 +1,75 @@
+use super::GroupProvider;
+use crate::steps::Step;
+use crate::{actions::group::GroupVariant, atoms::command::Exec};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+use which::which;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MacOsGroupProvider {}
+
+impl GroupProvider for MacOsGroupProvider {
+    fn add_group(&self, group: &GroupVariant) -> Vec<Step> {
+        let cli = match which("dscl") {
+            Ok(c) => c,
+            Err(_) => {
+                warn!(message = "Could not get the proper group add tool");
+                return vec![];
+            }
+        };
+
+        if group.group_name.is_empty() {
+            warn!(message = "Unable to create group without a group name");
+            return vec![];
+        }
+
+	let mut group_creation_string = String::from("/Groups/");
+        group_creation_string.push_str(group.group_name.clone().as_str());
+
+	let mut args: Vec<String> = vec![];
+	args.push(".".to_string());
+	args.push("create".to_string());
+	args.push(group_creation_string.to_owned());
+	
+
+        vec![Step {
+            atom: Box::new(Exec {
+                command: cli.display().to_string(),
+                arguments: args.into_iter().collect(),
+                privileged: true,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }]
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[cfg(test)]
+mod test {
+    use crate::actions::group::providers::{GroupProvider, MacOsGroupProvider};
+    use crate::actions::group::GroupVariant;
+
+    #[test]
+    fn test_add_group() {
+        let group_provider = MacOsGroupProvider {};
+        let steps = group_provider.add_group(&GroupVariant {
+            group_name: String::from("test"),
+            ..Default::default()
+        });
+
+        assert_eq!(steps.len(), 1);
+    }
+
+    #[test]
+    fn test_add_group_no_group_name() {
+        let group_provider = MacOsGroupProvider {};
+        let steps = group_provider.add_group(&GroupVariant {
+            // empty for test purposes
+            ..Default::default()
+        });
+
+        assert_eq!(steps.len(), 0);
+    }
+}

--- a/lib/src/actions/group/providers/mod.rs
+++ b/lib/src/actions/group/providers/mod.rs
@@ -33,7 +33,7 @@ impl GroupProviders {
             GroupProviders::None => Box::new(NoneGroupProvider {}),
             GroupProviders::FreeBSD => Box::new(FreeBSDGroupProvider {}),
             GroupProviders::Linux => Box::new(LinuxGroupProvider {}),
-	    GroupProviders::MacOs => Box::new(MacOsGroupProvider {}),
+            GroupProviders::MacOs => Box::new(MacOsGroupProvider {}),
         }
     }
 }
@@ -50,7 +50,7 @@ impl Default for GroupProviders {
 
         match info.os_type() {
             os_info::Type::FreeBSD => GroupProviders::FreeBSD,
-	    os_info::Type::Macos => GroupProviders::MacOs,
+            os_info::Type::Macos => GroupProviders::MacOs,
             _ => GroupProviders::None,
         }
     }

--- a/lib/src/actions/group/providers/mod.rs
+++ b/lib/src/actions/group/providers/mod.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 mod freebsd;
 mod linux;
 use self::linux::LinuxGroupProvider;
+mod macos;
+use self::macos::MacOsGroupProvider;
 
 #[derive(JsonSchema, Clone, Debug, Serialize, Deserialize)]
 pub enum GroupProviders {
@@ -20,6 +22,9 @@ pub enum GroupProviders {
 
     #[serde(alias = "linux")]
     Linux,
+
+    #[serde(alias = "macos")]
+    MacOs,
 }
 
 impl GroupProviders {
@@ -28,6 +33,7 @@ impl GroupProviders {
             GroupProviders::None => Box::new(NoneGroupProvider {}),
             GroupProviders::FreeBSD => Box::new(FreeBSDGroupProvider {}),
             GroupProviders::Linux => Box::new(LinuxGroupProvider {}),
+	    GroupProviders::MacOs => Box::new(MacOsGroupProvider {}),
         }
     }
 }
@@ -44,6 +50,7 @@ impl Default for GroupProviders {
 
         match info.os_type() {
             os_info::Type::FreeBSD => GroupProviders::FreeBSD,
+	    os_info::Type::Macos => GroupProviders::MacOs,
             _ => GroupProviders::None,
         }
     }

--- a/lib/src/actions/user/providers/macos.rs
+++ b/lib/src/actions/user/providers/macos.rs
@@ -43,7 +43,7 @@ impl UserProvider for MacOSUserProvider {
             args.push(String::from("\"{user.fullename}\""));
         }
 
-        let steps: Vec<Step> = vec![Step {
+        let mut steps: Vec<Step> = vec![Step {
             atom: Box::new(Exec {
                 command: cli.display().to_string(),
                 arguments: vec![].into_iter().chain(args.clone()).collect(),
@@ -54,12 +54,66 @@ impl UserProvider for MacOSUserProvider {
             finalizers: vec![],
         }];
 
+	if !user.group.is_empty() {
+	    let user_group = UserAddGroup {
+		username: user.username.clone(),
+		group: user.group.clone(),
+		provider: user.provider.clone(),
+	    };
+	    for group in self.add_to_group(&user_group)? {
+		steps.push(group);
+	    }
+	}
+
         Ok(steps)
     }
 
-    fn add_to_group(&self, _user: &UserAddGroup) -> anyhow::Result<Vec<Step>> {
-        warn!(message = "Adding users to group not implemented for platform");
-        Ok(vec![])
+    fn add_to_group(&self, user: &UserAddGroup) -> anyhow::Result<Vec<Step>> {
+	let cli = match which("dscl") {
+	    Ok(c) => c,
+	    Err(_) => {
+		warn!(message = "Could not find the dscl tool");
+		return Ok(vec![]);
+	    }
+	};
+
+	if user.group.is_empty() {
+	    warn!(message = "No groups listed to add user to");
+	    return Ok(vec![]);
+	}
+
+	if user.username.is_empty() {
+	    warn!(message = "No user specified to add to group(s)");
+	    return Ok(vec![]);
+	}
+
+	let mut steps: Vec<Step> = vec![];
+
+	for group in user.group.iter() {
+	    let mut group_string: String = String::from("/Groups/");
+	    group_string.push_str(&group.clone());
+	
+	    let mut args: Vec<String> = vec![];
+	    args.push(".".to_string());
+	    args.push("append".to_string());
+	    args.push(group_string.clone());
+	    args.push("GroupMembership".to_string());
+	    args.push(user.username.clone());
+
+	    steps.push(Step {
+		atom: Box::new(Exec {
+		    command: cli.display().to_string().clone(),
+		    arguments: args.into_iter().collect(),
+		    privileged: true,
+		    ..Default::default()
+		}),
+		initializers: vec![],
+		finalizers: vec![],
+	    });
+	}
+	
+	
+        Ok(steps)
     }
 }
 
@@ -67,7 +121,7 @@ impl UserProvider for MacOSUserProvider {
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{MacOSUserProvider, UserProvider};
-    use crate::actions::user::UserVariant;
+    use crate::actions::user::{add_group::UserAddGroup ,UserVariant};
 
     #[test]
     fn test_add_user() {
@@ -97,5 +151,32 @@ mod test {
         });
 
         assert_eq!(steps.unwrap().len(), 0);
+    }
+
+        #[test]
+    fn test_add_to_group() {
+        let user_provider = MacOSUserProvider {};
+        let steps = user_provider.add_to_group(&UserAddGroup {
+            username: String::from("test"),
+            group: vec![String::from("testgroup"), String::from("wheel")],
+            ..Default::default()
+        });
+
+        assert_eq!(steps.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_create_user_add_to_group() {
+        let user_provider = MacOSUserProvider {};
+        let steps = user_provider.add_user(&UserVariant {
+            username: String::from("test"),
+            shell: String::from(""),
+            home_dir: String::from(""),
+            fullname: String::from(""),
+            group: vec![String::from("testgroup")],
+            ..Default::default()
+        });
+
+        assert_eq!(steps.unwrap().len(), 2);
     }
 }

--- a/lib/src/actions/user/providers/macos.rs
+++ b/lib/src/actions/user/providers/macos.rs
@@ -54,65 +54,64 @@ impl UserProvider for MacOSUserProvider {
             finalizers: vec![],
         }];
 
-	if !user.group.is_empty() {
-	    let user_group = UserAddGroup {
-		username: user.username.clone(),
-		group: user.group.clone(),
-		provider: user.provider.clone(),
-	    };
-	    for group in self.add_to_group(&user_group)? {
-		steps.push(group);
-	    }
-	}
+        if !user.group.is_empty() {
+            let user_group = UserAddGroup {
+                username: user.username.clone(),
+                group: user.group.clone(),
+                provider: user.provider.clone(),
+            };
+            for group in self.add_to_group(&user_group)? {
+                steps.push(group);
+            }
+        }
 
         Ok(steps)
     }
 
     fn add_to_group(&self, user: &UserAddGroup) -> anyhow::Result<Vec<Step>> {
-	let cli = match which("dscl") {
-	    Ok(c) => c,
-	    Err(_) => {
-		warn!(message = "Could not find the dscl tool");
-		return Ok(vec![]);
-	    }
-	};
+        let cli = match which("dscl") {
+            Ok(c) => c,
+            Err(_) => {
+                warn!(message = "Could not find the dscl tool");
+                return Ok(vec![]);
+            }
+        };
 
-	if user.group.is_empty() {
-	    warn!(message = "No groups listed to add user to");
-	    return Ok(vec![]);
-	}
+        if user.group.is_empty() {
+            warn!(message = "No groups listed to add user to");
+            return Ok(vec![]);
+        }
 
-	if user.username.is_empty() {
-	    warn!(message = "No user specified to add to group(s)");
-	    return Ok(vec![]);
-	}
+        if user.username.is_empty() {
+            warn!(message = "No user specified to add to group(s)");
+            return Ok(vec![]);
+        }
 
-	let mut steps: Vec<Step> = vec![];
+        let mut steps: Vec<Step> = vec![];
 
-	for group in user.group.iter() {
-	    let mut group_string: String = String::from("/Groups/");
-	    group_string.push_str(&group.clone());
-	
-	    let mut args: Vec<String> = vec![];
-	    args.push(".".to_string());
-	    args.push("append".to_string());
-	    args.push(group_string.clone());
-	    args.push("GroupMembership".to_string());
-	    args.push(user.username.clone());
+        for group in user.group.iter() {
+            let mut group_string: String = String::from("/Groups/");
+            group_string.push_str(&group.clone());
 
-	    steps.push(Step {
-		atom: Box::new(Exec {
-		    command: cli.display().to_string().clone(),
-		    arguments: args.into_iter().collect(),
-		    privileged: true,
-		    ..Default::default()
-		}),
-		initializers: vec![],
-		finalizers: vec![],
-	    });
-	}
-	
-	
+            let mut args: Vec<String> = vec![];
+            args.push(".".to_string());
+            args.push("append".to_string());
+            args.push(group_string.clone());
+            args.push("GroupMembership".to_string());
+            args.push(user.username.clone());
+
+            steps.push(Step {
+                atom: Box::new(Exec {
+                    command: cli.display().to_string().clone(),
+                    arguments: args.into_iter().collect(),
+                    privileged: true,
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            });
+        }
+
         Ok(steps)
     }
 }
@@ -121,7 +120,7 @@ impl UserProvider for MacOSUserProvider {
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{MacOSUserProvider, UserProvider};
-    use crate::actions::user::{add_group::UserAddGroup ,UserVariant};
+    use crate::actions::user::{add_group::UserAddGroup, UserVariant};
 
     #[test]
     fn test_add_user() {
@@ -153,7 +152,7 @@ mod test {
         assert_eq!(steps.unwrap().len(), 0);
     }
 
-        #[test]
+    #[test]
     fn test_add_to_group() {
         let user_provider = MacOSUserProvider {};
         let steps = user_provider.add_to_group(&UserAddGroup {


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [X] feature
- [ ] documentation addition

## What is the current behaviour?

Group management is unimplemented

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Ability to add groups and users to groups on MacOS systems.

## What is the motivation / use case for changing the behavior?

Feature parity with other operating systems.

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.3
Operating system: MacOs 13.1
