### PR TITLE
Add more possible dirs to template context

### DIFF
--- a/lib/src/contexts/user.rs
+++ b/lib/src/contexts/user.rs
@@ -1,6 +1,6 @@
 use crate::contexts::{Context, ContextProvider};
 use anyhow::Result;
-use dirs_next::{config_dir, home_dir};
+use dirs_next::{config_dir, data_dir, data_local_dir, document_dir, home_dir};
 
 pub struct UserContextProvider {}
 
@@ -25,6 +25,24 @@ impl ContextProvider for UserContextProvider {
                 config_dir()
                     .map(Into::into)
                     .unwrap_or_else(|| "unknown".into()),
+            ),
+            Context::KeyValueContext(
+                String::from("data_dir"),
+                data_dir()
+                    .map(Into::into)
+                    .unwrap_or_else(|| "unknown".into())
+            ),
+            Context::KeyValueContext(
+                String::from("data_local_dir"),
+                data_local_dir()
+                    .map(Into::into)
+                    .unwrap_or_else(|| "unknown".into())
+            ),
+            Context::KeyValueContext(
+                String::from("document_dir"),
+                document_dir()
+                    .map(Into::into)
+                    .unwrap_or_else(|| "unknown".into())
             ),
         ])
     }

--- a/lib/src/contexts/user.rs
+++ b/lib/src/contexts/user.rs
@@ -30,19 +30,19 @@ impl ContextProvider for UserContextProvider {
                 String::from("data_dir"),
                 data_dir()
                     .map(Into::into)
-                    .unwrap_or_else(|| "unknown".into())
+                    .unwrap_or_else(|| "unknown".into()),
             ),
             Context::KeyValueContext(
                 String::from("data_local_dir"),
                 data_local_dir()
                     .map(Into::into)
-                    .unwrap_or_else(|| "unknown".into())
+                    .unwrap_or_else(|| "unknown".into()),
             ),
             Context::KeyValueContext(
                 String::from("document_dir"),
                 document_dir()
                     .map(Into::into)
-                    .unwrap_or_else(|| "unknown".into())
+                    .unwrap_or_else(|| "unknown".into()),
             ),
         ])
     }


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [X] feature
- [ ] documentation addition

## What is the current behaviour?

Adds data dir, local data dir, and document dir to possible contexts usages in templating.

## What is the motivation / use case for changing the behavior?

Most notably Neovim uses Local Appdata on windows. This makes linking it easier than manually constructing the command.

Since I was there, I added data and documents so I thought those could be useful for some setups.
