### PR TITLE
Initial package provider for luarocks

### DIFF
--- a/lib/src/actions/package/providers/luarocks.rs
+++ b/lib/src/actions/package/providers/luarocks.rs
@@ -1,0 +1,76 @@
+use super::PackageProvider;
+use crate::actions::package::repository::PackageRepository;
+use crate::steps::Step;
+use crate::{actions::package::PackageVariant, atoms::command::Exec};
+use serde::{Deserialize, Serialize};
+use tracing::{instrument, warn};
+use which::which;
+// use os_info;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LuaRocks {}
+
+impl PackageProvider for LuaRocks {
+    fn name(&self) -> &str {
+        "LuaRocks"
+    }
+
+    fn available(&self) -> bool {
+        match which("luarocks") {
+            Ok(_) => true,
+            Err(_) => {
+                warn!(message = "luarocks is not available");
+                false
+            }
+        }
+    }
+
+    #[instrument(name = "bootstrap", level = "info", skip(self))]
+    fn bootstrap(&self) -> Vec<Step> {
+	// TODO: Perhaps we can use the local OS provider package manager
+	// to bootstrap?
+        vec![]
+    }
+
+    fn has_repository(&self, _: &PackageRepository) -> bool {
+        false
+    }
+
+    fn add_repository(&self, _: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+        Ok(vec![])
+    }
+
+    // TODO: Handle query pkgs with pkgin search
+    fn query(&self, package: &PackageVariant) -> anyhow::Result<Vec<String>> {
+        // Install all packages for now, don't get smart about which
+        // already are
+        Ok(package.packages())
+    }
+
+    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+	let cli = match which("luarocks") {
+	    Ok(c) => c,
+	    Err(_) => {
+		warn!(message = "LuaRocks is not available.");
+		return Ok(vec![]);
+	    }
+	};
+	
+        Ok(vec![
+            Step {
+                atom: Box::new(Exec {
+                    command: cli.display().to_string(),
+                    arguments: vec![String::from("install")]
+                        .into_iter()
+                        .chain(package.extra_args.clone())
+                        .chain(package.packages())
+                        .collect(),
+                    privileged: true,
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            }
+        ])
+    }
+}

--- a/lib/src/actions/package/providers/luarocks.rs
+++ b/lib/src/actions/package/providers/luarocks.rs
@@ -27,8 +27,8 @@ impl PackageProvider for LuaRocks {
 
     #[instrument(name = "bootstrap", level = "info", skip(self))]
     fn bootstrap(&self) -> Vec<Step> {
-	// TODO: Perhaps we can use the local OS provider package manager
-	// to bootstrap?
+        // TODO: Perhaps we can use the local OS provider package manager
+        // to bootstrap?
         vec![]
     }
 
@@ -48,29 +48,27 @@ impl PackageProvider for LuaRocks {
     }
 
     fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
-	let cli = match which("luarocks") {
-	    Ok(c) => c,
-	    Err(_) => {
-		warn!(message = "LuaRocks is not available.");
-		return Ok(vec![]);
-	    }
-	};
-	
-        Ok(vec![
-            Step {
-                atom: Box::new(Exec {
-                    command: cli.display().to_string(),
-                    arguments: vec![String::from("install")]
-                        .into_iter()
-                        .chain(package.extra_args.clone())
-                        .chain(package.packages())
-                        .collect(),
-                    privileged: true,
-                    ..Default::default()
-                }),
-                initializers: vec![],
-                finalizers: vec![],
+        let cli = match which("luarocks") {
+            Ok(c) => c,
+            Err(_) => {
+                warn!(message = "LuaRocks is not available.");
+                return Ok(vec![]);
             }
-        ])
+        };
+
+        Ok(vec![Step {
+            atom: Box::new(Exec {
+                command: cli.display().to_string(),
+                arguments: vec![String::from("install")]
+                    .into_iter()
+                    .chain(package.extra_args.clone())
+                    .chain(package.packages())
+                    .collect(),
+                privileged: true,
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }])
     }
 }

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -68,7 +68,7 @@ impl PackageProviders {
             PackageProviders::BsdPkg => Box::new(BsdPkg {}),
             PackageProviders::Dnf => Box::new(Dnf {}),
             PackageProviders::Homebrew => Box::new(Homebrew {}),
-	    PackageProviders::LuaRocks => Box::new(LuaRocks {}),
+            PackageProviders::LuaRocks => Box::new(LuaRocks {}),
             PackageProviders::Macports => Box::new(Macports {}),
             PackageProviders::Pkgin => Box::new(Pkgin {}),
             PackageProviders::Yay => Box::new(Yay {}),

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -7,6 +7,8 @@ mod dnf;
 use self::dnf::Dnf;
 mod homebrew;
 use self::homebrew::Homebrew;
+mod luarocks;
+use self::luarocks::LuaRocks;
 mod macports;
 use self::macports::Macports;
 mod pkgin;
@@ -37,6 +39,9 @@ pub enum PackageProviders {
     #[serde(rename = "homebrew", alias = "brew")]
     Homebrew,
 
+    #[serde(rename = "luarocks", alias = "luarocks")]
+    LuaRocks,
+
     #[serde(rename = "macports", alias = "port")]
     Macports,
 
@@ -63,6 +68,7 @@ impl PackageProviders {
             PackageProviders::BsdPkg => Box::new(BsdPkg {}),
             PackageProviders::Dnf => Box::new(Dnf {}),
             PackageProviders::Homebrew => Box::new(Homebrew {}),
+	    PackageProviders::LuaRocks => Box::new(LuaRocks {}),
             PackageProviders::Macports => Box::new(Macports {}),
             PackageProviders::Pkgin => Box::new(Pkgin {}),
             PackageProviders::Yay => Box::new(Yay {}),


### PR DESCRIPTION
implementing the install action

## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

Install packages with luarocks by specifying a luarocks provider

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Ability to install lua modules via luarocks.

## What is the motivation / use case for changing the behavior?

#311 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.3
Operating system: Fedora 37
