### PR TITLE
change the example for linux so not to cause a system reboot

### DIFF
--- a/examples/onlyvariants/main.yaml
+++ b/examples/onlyvariants/main.yaml
@@ -7,7 +7,8 @@ actions:
       - hello, world!
     variants:
       - where: os.name == "linux"
-        command: reboot
+        command: echo
+        args: ["Hello", "Linux"]
       - where: os.name == "macos"
         command: echo
         args: ["Hello", "macOS"]


### PR DESCRIPTION
Change the example variant to remove rebooting on a linux variant.
