### PR TITLE
add unarchive atom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "anyhow",
  "dirs-next",
  "file_diff",
+ "flate2",
  "gethostname",
  "gitsync",
  "ignore",
@@ -490,6 +491,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha256",
+ "tar",
  "tempfile",
  "tera",
  "tokio",
@@ -841,6 +843,18 @@ name = "file_diff"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
+
+[[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys",
+]
 
 [[package]]
 name = "find-crate"
@@ -3135,6 +3149,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4084,6 +4109,15 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,6 +38,8 @@ trust-dns-resolver = "0.23.2"
 walkdir = "2.3"
 which = "5.0"
 whoami = "1.4"
+tar = "0.4.40"
+flate2 = "1.0.28"
 
 [target.'cfg(unix)'.dependencies]
 uzers = "0.11"

--- a/lib/src/atoms/file/mod.rs
+++ b/lib/src/atoms/file/mod.rs
@@ -6,6 +6,7 @@ mod create;
 mod decrypt;
 mod link;
 mod remove;
+mod unarchive;
 
 use super::Atom;
 pub use chmod::Chmod;
@@ -16,6 +17,7 @@ pub use create::Create;
 pub use decrypt::Decrypt;
 pub use link::Link;
 pub use remove::Remove;
+pub use unarchive::Unarchive;
 
 pub trait FileAtom: Atom {
     // Don't think this is needed? Validate soon

--- a/lib/src/atoms/file/unarchive.rs
+++ b/lib/src/atoms/file/unarchive.rs
@@ -1,0 +1,65 @@
+use std::{fs::File, path::PathBuf};
+
+use flate2::read::GzDecoder;
+use tar::Archive;
+
+use crate::atoms::{Atom, Outcome};
+
+use super::FileAtom;
+
+pub struct Unarchive {
+    pub origin: PathBuf,
+    pub dest: PathBuf,
+    pub force: bool,
+}
+
+impl FileAtom for Unarchive {
+    fn get_path(&self) -> &PathBuf {
+        &self.origin
+    }
+}
+
+impl Atom for Unarchive {
+    // Determine if this atom needs to run
+    fn plan(&self) -> anyhow::Result<Outcome> {
+        if self.dest.exists() {
+            if self.force {
+                return Ok(Outcome {
+                    side_effects: vec![],
+                    should_run: self.origin.exists(),
+                });
+            }
+            return Ok(Outcome {
+                side_effects: vec![],
+                should_run: false,
+            });
+        }
+
+        return Ok(Outcome {
+            side_effects: vec![],
+            should_run: self.origin.exists(),
+        });
+    }
+
+    // Apply new to old
+    fn execute(&mut self) -> anyhow::Result<()> {
+        let tar_gz = File::open(&self.origin)?;
+        let tar = GzDecoder::new(tar_gz);
+        let mut archive = Archive::new(tar);
+        archive.unpack(&self.dest)?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for Unarchive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let origin_path = self.origin.display().to_string();
+        let dest_path = self.dest.display().to_string();
+
+        write!(
+            f,
+            "The archive {} to be decompressed to {}",
+            origin_path, dest_path
+        )
+    }
+}


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

Comtrya does not have anything to unarchive a compressed file

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Add an atom that can be built upon to uncompress a tar ball.

## What is the motivation / use case for changing the behavior?

Seems like something useful.

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.7
Operating system: macOS 14.1
