### PR TITLE
update ubuntu runners and update gitignore

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,8 +73,8 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-20.04, target: aarch64-unknown-linux-gnu }
-          - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
 
           - { os: macos-12, target: x86_64-apple-darwin }
           - { os: macos-12, target: aarch64-apple-darwin }

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,7 +63,7 @@ jobs:
           #     target: aarch64-unknown-linux-gnu,
           #     use-cross: true,
           #   }
-          - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           # - {
           #     os: ubuntu-20.04,
           #     target: x86_64-unknown-linux-musl,

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /_cicd-intermediates
 /.build
+.DS_Store


### PR DESCRIPTION
Chore: noticed that some ubuntu runners were using 20.04 when 22.04 is available.
