### PR TITLE
fix: attempt to fix aarch64 linux binaries

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --release ${{ matrix.job.target }}
 
       - name: Rename Binary
         if: matrix.job.target != 'x86_64-pc-windows-msvc'
@@ -163,7 +163,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --release ${{ matrix.job.target }}
 
       - name: Rename Binary
         shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, use-cross: true }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
 
           - { os: macos-12, target: x86_64-apple-darwin }
@@ -163,7 +163,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release ${{ matrix.job.target }}
+          args: --release --target ${{ matrix.job.target }}
 
       - name: Rename Binary
         shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release ${{ matrix.job.target }}
+          args: --release --target ${{ matrix.job.target }}
 
       - name: Rename Binary
         if: matrix.job.target != 'x86_64-pc-windows-msvc'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg add-architecture arm64 sudo apt-get -y install libssl-dev:arm64 ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg --add-architecture arm64 sudo apt-get -y install libssl-dev:arm64 ;;
           esac
 
       - shell: bash

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg --add-architecture arm64 sudo apt-get -y install libssl-dev:arm64 ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg --add-architecture arm64 ; sudo apt-get -y install libssl-dev:arm64 ;;
           esac
 
       - shell: bash

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -64,6 +64,7 @@ jobs:
           #     use-cross: true,
           #   }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuuntu-22.04, target: aarch64-unknown-linux-gnu }
           # - {
           #     os: ubuntu-20.04,
           #     target: x86_64-unknown-linux-musl,

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -99,4 +99,4 @@ jobs:
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+          args: --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,7 +63,7 @@ jobs:
           #     target: aarch64-unknown-linux-gnu,
           #     use-cross: true,
           #   }
-          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, use-cross: true }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           # - {
           #     os: ubuntu-20.04,

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg --add-architecture arm64 ; sudo apt-get -y install libssl-dev:arm64 ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg --add-architecture arm64 ; sudo apt-get -y update ; sudo apt-get -y install libssl-dev:arm64 ;;
           esac
 
       - shell: bash

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg --add-architecture arm64 ; sudo apt-get -y update ; sudo apt-get -y install libssl-dev:arm64 ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
           esac
 
       - shell: bash

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,7 +63,7 @@ jobs:
           #     target: aarch64-unknown-linux-gnu,
           #     use-cross: true,
           #   }
-          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, use-cross: true }
+          # - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, use-cross: true }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           # - {
           #     os: ubuntu-20.04,

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo apt-get -y install libssl-dev:arm64 ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg-add-architecture arm64 sudo apt-get -y install libssl-dev:arm64 ;;
           esac
 
       - shell: bash

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo apt-get -y install libssl-dev:arm64 ;;
           esac
 
       - shell: bash

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,7 +63,7 @@ jobs:
           #     target: aarch64-unknown-linux-gnu,
           #     use-cross: true,
           #   }
-          - { os: ubuuntu-22.04, target: aarch64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           # - {
           #     os: ubuntu-20.04,

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg-add-architecture arm64 sudo apt-get -y install libssl-dev:arm64 ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ; sudo dpkg add-architecture arm64 sudo apt-get -y install libssl-dev:arm64 ;;
           esac
 
       - shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "ignore",
  "normpath",
  "octocrab",
+ "openssl-sys",
  "os_info",
  "petgraph",
  "pretty_assertions",
@@ -1900,6 +1901,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.1.6+3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +1917,7 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,6 +39,10 @@ walkdir = "2.3"
 which = "5.0"
 whoami = "1.4"
 
+[dependencies.openssl-sys]
+version="0.9"
+features = ["vendored"]
+
 [target.'cfg(unix)'.dependencies]
 uzers = "0.11"
 


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Binaries for aarch64-unknown-linux-gnu are not compiled correctly in the artifacts.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

aarch64-unknown-linux-gnu binary is an actual aarch64 binary

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
