### PR TITLE
Add some forgotten conversion from matrix.job to matrix.platform

### DIFF
--- a/.github/workflows/main2.yaml
+++ b/.github/workflows/main2.yaml
@@ -127,13 +127,13 @@ jobs:
           args: "--release"
           
       - name: Rename Binary
-        if: matrix.job.target != 'x86_64-pc-windows-msvc'
+        if: matrix.platform.target != 'x86_64-pc-windows-msvc'
         shell: bash
         run: |
           mv target/release/comtrya comtrya-${{ matrix.platform.target }}
 
       - name: Rename Binary.exe
-        if: matrix.job.target == 'x86_64-pc-windows-msvc'
+        if: matrix.platform.target == 'x86_64-pc-windows-msvc'
         shell: bash
         run: |
           mv target/release/comtrya.exe comtrya-${{ matrix.platform.target }}.exe


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
