### PR TITLE
chore: sudo should be called privileged in command.execute

### DIFF
--- a/examples/command/run.yaml
+++ b/examples/command/run.yaml
@@ -7,7 +7,7 @@ actions:
 
   - action: command.run
     command: whoami
-    sudo: true
+    privileged: true
 
   - action: command.run
     command: ls
@@ -20,4 +20,4 @@ actions:
       - "-c"
       - "curl -sfL https://get.k3s.io | sh -"
     dir: .
-    sudo: true
+    privileged: true

--- a/lib/src/actions/command/run.rs
+++ b/lib/src/actions/command/run.rs
@@ -11,8 +11,8 @@ pub struct RunCommand {
     #[serde(default)]
     pub args: Vec<String>,
 
-    #[serde(default = "get_false")]
-    pub sudo: bool,
+    #[serde(default = "get_false", alias = "sudo")]
+    pub privileged: bool,
 
     #[serde(default = "get_cwd")]
     pub dir: String,
@@ -36,7 +36,7 @@ impl Action for RunCommand {
             atom: Box::new(Exec {
                 command: self.command.clone(),
                 arguments: self.args.clone(),
-                privileged: self.sudo,
+                privileged: self.privileged,
                 working_dir: Some(self.dir.clone()),
                 ..Default::default()
             }),

--- a/lib/src/actions/mod.rs
+++ b/lib/src/actions/mod.rs
@@ -257,7 +257,7 @@ actions:
             RunCommand {
                 command: "echo".into(),
                 args: vec!["hi".into()],
-                sudo: false,
+                privileged: false,
                 dir: std::env::current_dir()
                     .unwrap()
                     .into_os_string()


### PR DESCRIPTION
## I'm submitting a

Chore

## What is the current behaviour?

Related to #318 

`sudo` won't always be how we elevate privileges, and the atoms we built actually allow for abstracted `privilege` elevation, not sudo. Our `command.execute` action was specifically expecting `sudo: true`.

This is an intermediate solution where we support both `sudo: true` and `privileged: true`, and in the future we may support alternative elevations (teleport, doas, ?)