### PR TITLE
fix: error when there's unrecognized fields in manifest

### DIFF
--- a/lib/src/actions/mod.rs
+++ b/lib/src/actions/mod.rs
@@ -33,6 +33,7 @@ use user::add::UserAdd;
 use self::user::add_group::UserAddGroup;
 
 #[derive(JsonSchema, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ConditionalVariantAction<T> {
     #[serde(flatten)]
     pub action: T,
@@ -98,7 +99,7 @@ where
 }
 
 #[derive(JsonSchema, Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "action")]
+#[serde(deny_unknown_fields, tag = "action")]
 pub enum Actions {
     #[serde(rename = "command.run", alias = "cmd.run")]
     CommandRun(ConditionalVariantAction<RunCommand>),

--- a/lib/src/manifests/load.rs
+++ b/lib/src/manifests/load.rs
@@ -92,9 +92,9 @@ pub fn load(manifest_path: PathBuf, contexts: &Contexts) -> HashMap<String, Mani
                     .and_then(OsStr::to_str)
                 {
                     Some("yaml") | Some("yml") => {
-                        serde_yaml::from_str(template.deref()).map_err(anyhow::Error::from)
+                        serde_yaml::from_str::<Manifest>(template.deref()).map_err(anyhow::Error::from)
                     }
-                    Some("toml") => toml::from_str(template.deref()).map_err(anyhow::Error::from),
+                    Some("toml") => toml::from_str::<Manifest>(template.deref()).map_err(anyhow::Error::from),
                     _ => {
                         error!("Unrecognized file extension for manifest");
                         span.exit();

--- a/lib/src/manifests/mod.rs
+++ b/lib/src/manifests/mod.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use tracing::error;
 
 #[derive(JsonSchema, Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Manifest {
     #[serde(default)]
     pub r#where: Option<String>,


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Closes #318 

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
