### PR TITLE
Directory sanity check

### DIFF
--- a/lib/src/actions/file/mod.rs
+++ b/lib/src/actions/file/mod.rs
@@ -44,9 +44,7 @@ pub trait FileAction: Action {
             .join(path);
 
         if file_path.is_dir() {
-            return Err(anyhow!(
-                "Expected a file, but found a directory"
-            ));
+            return Err(anyhow!("Expected a file, but found a directory"));
         }
 
         std::fs::read(file_path.clone()).map_err(|e| match e.kind() {

--- a/lib/src/actions/file/mod.rs
+++ b/lib/src/actions/file/mod.rs
@@ -43,6 +43,12 @@ pub trait FileAction: Action {
             .join("files")
             .join(path);
 
+        if file_path.is_dir() {
+            return Err(anyhow!(
+                "Expected a file, but found a directory"
+            ));
+        }
+
         std::fs::read(file_path.clone()).map_err(|e| match e.kind() {
             ErrorKind::NotFound => anyhow!(
                 "Failed because {} was not found",


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

It is reported that running the file copy against a directory on linux fails as it should, but it changes the directory permissions. As per issue #315 

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

Repro steps provided in #315 

## What is the expected behavior?

Fail action, but not modify behavior. It should also give a valid failure message that a file was expected but a directory was provided.

## What is the motivation / use case for changing the behavior?

Bug report

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.8
Operating system: macOS apple silicon Sonoma and Debian Linux
