### PR TITLE
Add action summary information. (#254)

### DIFF
--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -250,6 +250,7 @@ impl ComtryaCommand for Apply {
                             break;
                         }
                     }
+                    info!("{}", action.summarize());
                     span_action.exit();
                 }
 

--- a/lib/src/actions/file/copy.rs
+++ b/lib/src/actions/file/copy.rs
@@ -35,6 +35,9 @@ impl FileCopy {}
 impl FileAction for FileCopy {}
 
 impl Action for FileCopy {
+    fn summarize(&self) -> String {
+        format!("copy file from {} to {}", self.from, self.to)
+    }
     fn plan(
         &self,
         manifest: &Manifest,
@@ -84,7 +87,6 @@ impl Action for FileCopy {
 
         let path = PathBuf::from(&self.to);
         let parent = path.clone();
-
         let mut steps = vec![
             Step {
                 atom: Box::new(DirCreate {

--- a/lib/src/actions/mod.rs
+++ b/lib/src/actions/mod.rs
@@ -228,11 +228,8 @@ impl<E: std::error::Error> From<E> for ActionError {
 
 pub trait Action {
     fn summarize(&self) -> String {
-        warn!(
-            "not found action summarize: {}",
-            std::any::type_name_of_val(self)
-        );
-        format!("{:?}", std::any::type_name_of_val(self))
+        warn!("need to define action summarize");
+        format!("not found action summarize")
     }
     fn plan(&self, manifest: &Manifest, context: &Contexts) -> anyhow::Result<Vec<Step>>;
 }


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ *] feature
- [ ] documentation addition

## What is the current behaviour?
Even run ``` -vv (tracing mode),``` didn't provide action key information.
For example CopyFile, can't figure out about source and destination.


## current output look like,

```
TRACE load_config{args=GlobalArgs { manifest_directory: None, no_color: false, verbose: 2, command: Apply(Apply { manifests: [], dry_run: false, label: None }) }}:load_config: No Comtrya.yaml found in current working directory
TRACE load_config{args=GlobalArgs { manifest_directory: None, no_color: false, verbose: 2, command: Apply(Apply { manifests: [], dry_run: false, label: None }) }}:load_config: No Comtrya.yaml found in users config directory
TRACE build_contexts: context="user" key="id" value="1000"
...
TRACE build_contexts: context="env" key="MANAGERPID" value="116167"
TRACE execute: manifests=""
...
TRACE execute: Add dynamic constant 'user' -> #{"config_dir": "/home/shawn/.config", "data_dir": "/home/shawn/.local/share", "data_local_dir": "/home/shawn/.local/share", "document_dir": "/home/shawn/Documents", "home_dir": "/home/shawn", "id": "1000", "name": "Shawn Wang", "username": "shawn"}
TRACE execute: Add dynamic constant 'variables' -> #{}
...
TRACE execute:{manifest="sops"}:{action=file.copy}: Add dynamic constant 'user' -> #{"config_dir": "/home/shawn/.config", "data_dir": "/home/shawn/.local/share", "data_local_dir": "/home/shawn/.local/share", "document_dir": "/home/shawn/Documents", "home_dir": "/home/shawn", "id": "1000", "name": "Shawn Wang", "username": "shawn"}
TRACE execute:{manifest="sops"}:{action=file.copy}: Add dynamic constant 'variables' -> #{}
 INFO execute:{manifest="sops"}: Completed
```


## What is the expected behavior?

```
╰─❯ /home/shawn/comtrya/target/debug/comtrya   apply
 INFO execute:{manifest="sops"}:{action=file.copy}: copy file from x1234 to y
 INFO execute:{manifest="sops"}: Completed
╰─❯ /home/shawn/comtrya/target/debug/comtrya   apply --dry-run
 INFO execute:{manifest="sops"}:{action=file.copy}: copy file from x1234 to y
```

## Please tell us about your environment:

Version (`comtrya --version`): comtrya 0.8.8
Operating system: linux
