### PR TITLE
fix: vartiants examples

### DIFF
--- a/docs/src/variants.md
+++ b/docs/src/variants.md
@@ -33,11 +33,14 @@ actions:
       - hello, vanilla Linux!
     variants:
       - where: os.family == "unix"
-        command: echo Hi, Unix
+        command: echo
+        args: ["Hi,", "Unix"]
       - where: os.distribution == "Ubuntu"
-        command: echo Hi, Ubuntu
+        command: echo
+        args: ["Hi,", "Ubuntu"]
       - where: os.bitness == "64-bit"
-        command: echo Hi, 64 bit!
+        command: echo
+        args: ["Hi,", "64 bit!"]
 ```
 
 Lastly, the `where` clause can be used to selectively skip or run tasks:


### PR DESCRIPTION
## I'm submitting a

- [ *] bug fix
- [ ] feature
- [ *] documentation addition

It's a small error.

## What is the current behaviour?

```
actions:
  - action: command.run
    command: echo
    args:
      - hello, vanilla Linux!
    variants:
      - where: os.family == "unix"
        command: echo Hi, Unix
      - where: os.distribution == "Ubuntu"
        command: echo Hi, Ubuntu
      - where: os.bitness == "64-bit"
        command: echo Hi, 64 bit!
```

```
DEBUG execute:{manifest="b"}:{action=command.run}: Atom failed to execute: No such file or directory (os error 2)
ERROR execute:{manifest="b"}: Failed
```

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?


```
TRACE execute:{manifest="c"}:{action=command.run}: stdout: Hi, Unix
```


## Please tell us about your environment:

Version (`comtrya --version`): 0.8.8
Operating system: Linux
