### PR TITLE
update min rust version

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,7 @@
 name: pull-request
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.70.0"
+  MIN_SUPPORTED_RUST_VERSION: "1.73.0"
 
 on:
   pull_request:


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [ ] documentation addition
- [x] Chore

## What is the current behaviour?

Taurplin fails because min rust verison is 1.70 in pull-request.yaml

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

CI pipeline runs for pull-request.yaml

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
