### PR TITLE
add tracing_journald support for linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "tracing",
+ "tracing-journald",
  "tracing-subscriber",
  "update-informer",
 ]
@@ -3641,6 +3642,17 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-journald"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -17,6 +17,7 @@ rhai = { version = "1.17", features = ["serde"] }
 strip-ansi-escapes = "0.2"
 structopt = { version = "0.3", features = ["paw"] }
 tracing = "0.1"
+tracing-journald = "0.3.0"
 tracing-subscriber = "0.3"
 update-informer = "1.1"
 


### PR DESCRIPTION
## I'm submitting a


- [ ] bug fix
- [x] feature
- [ ] documentation addition


## What is the current behaviour?

directly output log to stdout.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

It's not a bug, more like a log enhancement with journalctl. #254 

Once, tracing_journald supported.
```
 journalctl -f  F_MANIFEST=zellij -o json-pretty

{
        "CODE_LINE" : "268",
...
        "SYSLOG_IDENTIFIER" : "comtrya",
        "_COMM" : "comtrya",
        "F_MANIFEST" : "zellij",
        "SPAN_TARGET" : "comtrya::commands::apply",
        "TARGET" : "comtrya::commands::apply",
...
}
```
## What is the expected behavior?
```
journalctl -t comtrya                       ### all comtrya log
journalctl -t comtrya F_MANIFEST=zellij     ### comtrya manifest zellij log       
```
## What is the motivation / use case for changing the behavior?

Linux users can easy trace manifests actions by journalctl.

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.8
Operating system: Fedora
