### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,15 +128,16 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -492,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
  "proc-macro-hack",


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

Updated AHash with `cargo update ahash`

## What is the current behaviour?
Can't build from source anymore due to AHash updates.
More info can be found here https://github.com/tkaitchuck/aHash/issues/200

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
Re-clone the repo and try to build it from scratch

## What is the expected behavior?
The build should finish with no errors

## Please tell us about your environment:
Running on Ubuntu 20.04.6 LTS

Version (`comtrya --version`):
Operating system: comtrya 0.8.8
Running on Ubuntu 20.04.6 LTS