### PR TITLE
refactor: replace structopt/paw with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,15 +165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,17 +248,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.55",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -443,26 +423,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -475,6 +441,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -517,15 +495,14 @@ version = "0.8.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "clap",
  "colored",
  "comfy-table",
  "comtrya-lib",
- "paw",
  "petgraph",
  "predicates",
  "rhai",
  "strip-ansi-escapes",
- "structopt",
  "tempfile",
  "tracing",
  "tracing-journald",
@@ -1428,27 +1405,15 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1913,7 +1878,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2192,7 +2157,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2374,33 +2339,6 @@ checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
  "regex",
 ]
-
-[[package]]
-name = "paw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c0fc9b564dbc3dc2ed7c92c0c144f4de340aa94514ce2b446065417c4084e9"
-dependencies = [
- "paw-attributes",
- "paw-raw",
-]
-
-[[package]]
-name = "paw-attributes"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f35583365be5d148e959284f42526841917b7bfa09e2d1a7ad5dde2cf0eaa39"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "paw-raw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0b59668fe80c5afe998f0c0bf93322bf2cd66cafeeb80581f291716f3467f2"
 
 [[package]]
 name = "pbkdf2"
@@ -3522,12 +3460,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -3537,31 +3469,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "paw",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -3706,15 +3613,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thin-vec"
@@ -4209,12 +4107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,12 +4215,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -4762,7 +4648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940db5674e301470e6cd91098b2c68a1fad751a1623575d1133f7456146e6d2f"
 dependencies = [
  "anyhow",
- "clap 4.5.4",
+ "clap",
  "derive_builder",
  "dialoguer",
  "dtt",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -8,14 +8,13 @@ description = "A tool to simplify reprovisioning a fresh OS. Installs packages a
 
 [dependencies]
 anyhow = "1.0"
+clap = { version = "4.5.4", features = ["derive"] }
 colored = "2.1"
 comfy-table = "7"
 comtrya-lib = { path = "../lib", version = "0.8.8" }
-paw = "1.0"
 petgraph = "0.6"
 rhai = { version = "1.17", features = ["serde"] }
 strip-ansi-escapes = "0.2"
-structopt = { version = "0.3", features = ["paw"] }
 tracing = "0.1"
 tracing-journald = "0.3.0"
 tracing-subscriber = "0.3"

--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -1,25 +1,26 @@
 use super::ComtryaCommand;
 use crate::Runtime;
+use clap::Parser;
 use comtrya_lib::contexts::to_rhai;
 use comtrya_lib::manifests::{load, Manifest};
 use core::panic;
 use petgraph::{visit::DfsPostOrder, Graph};
 use rhai::Engine;
 use std::{collections::HashMap, ops::Deref};
-use structopt::StructOpt;
 use tracing::{debug, error, info, instrument, span, trace, warn};
 
-#[derive(Clone, Debug, StructOpt)]
+#[derive(Parser, Debug)]
 pub(crate) struct Apply {
     /// Run a subset of your manifests, comma separated list
-    #[structopt(short = "m", long, use_delimiter = true)]
+    #[arg(short, long, value_delimiter = ',')]
     manifests: Vec<String>,
 
     /// Performs a dry-run without changing the system
-    #[structopt(long)]
+    #[arg(long)]
     dry_run: bool,
 
-    #[structopt(short = "l", long = "label")]
+    /// Define label selector
+    #[arg(short, long)]
     pub label: Option<String>,
 }
 

--- a/app/src/commands/contexts.rs
+++ b/app/src/commands/contexts.rs
@@ -2,12 +2,14 @@ use super::ComtryaCommand;
 use crate::Runtime;
 use colored::Colorize;
 use comfy_table::{presets::NOTHING, Attribute, Cell, ContentArrangement, Table};
-use structopt::StructOpt;
 
-#[derive(Clone, Debug, StructOpt)]
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command()]
 pub(crate) struct Contexts {
     /// Show the values of the contexts
-    #[structopt(long)]
+    #[arg(long)]
     show_values: bool,
 }
 

--- a/app/src/commands/version.rs
+++ b/app/src/commands/version.rs
@@ -1,8 +1,10 @@
 use super::ComtryaCommand;
 use crate::Runtime;
-use structopt::StructOpt;
 
-#[derive(Clone, Debug, StructOpt)]
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command()]
 pub(crate) struct Version {}
 
 impl ComtryaCommand for Version {

--- a/app/src/config/mod.rs
+++ b/app/src/config/mod.rs
@@ -5,9 +5,9 @@ pub use comtrya_lib::config::Config;
 use tracing::instrument;
 
 #[instrument(name = "load_config", level = "info")]
-pub(crate) fn load_config(args: GlobalArgs) -> Result<Config> {
+pub(crate) fn load_config(args: &GlobalArgs) -> Result<Config> {
     match lib_config() {
-        Ok(config) => match args.manifest_directory {
+        Ok(config) => match args.manifest_directory.clone() {
             Some(manifest_path) => Ok(Config {
                 manifest_paths: vec![manifest_path],
                 ..config


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?
As https://github.com/TeXitoi/structopt mention clap already support derive and structopt would not add new features.

## What is the motivation / use case for changing the behavior?
Switch to clap, clean some dependency.

