### PR TITLE
correct install option

### DIFF
--- a/lib/src/actions/package/providers/bsdpkg.rs
+++ b/lib/src/actions/package/providers/bsdpkg.rs
@@ -66,7 +66,7 @@ impl PackageProvider for BsdPkg {
             Step {
                 atom: Box::new(Exec {
                     command: String::from("/usr/sbin/pkg"),
-                    arguments: vec![String::from("install"), String::from("-n")]
+                    arguments: vec![String::from("install"), String::from("-y")]
                         .into_iter()
                         .chain(package.extra_args.clone())
                         .chain(package.packages())


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?
bsdpkg provider fails to install.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
Run the following manifest snippet on a FreeBSD system
```
actions:
  - action: package.install
    list:
    - sd
    - just
```

## What is the expected behavior?
Should install successfully

## What is the motivation / use case for changing the behavior?
Refer to issue #433 

We pass in the `-n` option when it should be `-y` so that way comtrya can automatically pass in the yes option when prompted with the 'are you sure' prompt from the package manager.

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.8
Operating system: FreeBSD 14.1
