### PR TITLE
Add asking for manifests in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,6 +8,9 @@ title: "Bug:"
 **Description**
 Describe the bug in your own words.
 
+**Example manifest**
+Can you provide an example manifest that can demonstrate the problem?
+
 **Steps to reproduce**
 Step by step explanation. Please add the output of with `-vvv` flag enabled (be careful not to include any secrets from your config).
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,3 +10,6 @@ Describe the idea / feature request in your own words.
 
 **Additional information**
 Add more context which didn't fit in the fields above.
+
+**Manifest Example**
+If this requires a change or additions to manifests such as properties, or if this is a proposed new action, can you provide an example of what it should look like in a manifest file?


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## Description

Add sections in issue templates to ask for manifest examples.