### PR TITLE
More ci updates

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -110,7 +110,7 @@ jobs:
             target: aarch64-apple-darwin
             bin: comtrya
             name: comtrya-aarch64-apple-darwin
-            cross: true
+            cross: false
             cargo_command: ./cross
             skip_tests: false
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         platform:
           - os_name: Linux-x86_64-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             bin: comtrya
             name: comtrya-x86_64-unknown-linux-gnu
@@ -82,7 +82,7 @@ jobs:
             cargo_command: cargo
             skip_tests: false
           - os_name: Linux-aarch64-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             bin: comtrya
             name: comtrya-aarch64-unknown-linux-gnu

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,7 +63,7 @@ jobs:
           #     target: aarch64-unknown-linux-gnu,
           #     use-cross: true,
           #   }
-          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-24.04, target: x86_64-unknown-linux-gnu }
           # - {
           #     os: ubuntu-20.04,
           #     target: x86_64-unknown-linux-musl,


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?
Current linux runners use 22.04. 24.04 is now available.

## What is the expected behavior?
Linux test runners will run on 24.04

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):v0.8.8
Operating system:N/A
