### PR TITLE
Change some trace to warn message and some debug to error messages

### DIFF
--- a/lib/src/atoms/file/link.rs
+++ b/lib/src/atoms/file/link.rs
@@ -3,7 +3,7 @@ use crate::atoms::Outcome;
 use super::super::Atom;
 use super::FileAtom;
 use std::path::PathBuf;
-use tracing::{debug, error, warn};
+use tracing::{error, warn};
 
 pub struct Link {
     pub source: PathBuf,
@@ -59,7 +59,7 @@ impl Atom for Link {
                     "Cannot plan: target already exists and isn't a link: {}",
                     self.target.display()
                 );
-                debug!("Cannot plan: {}", err);
+                error!("Cannot plan: {}", err);
 
                 return Ok(Outcome {
                     side_effects: vec![],

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::PathBuf, vec};
-use tracing::{debug, instrument, trace};
+use tracing::{instrument, trace, warn};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Config {
@@ -62,7 +62,7 @@ fn find_configs() -> Option<PathBuf> {
         let local_config = cwd.join("Comtrya.yaml");
 
         if local_config.is_file() {
-            debug!("Comtrya.yaml found in current working directory");
+            warn!("Comtrya.yaml found in current working directory");
             return Some(local_config);
         }
         trace!("No Comtrya.yaml found in current working directory");
@@ -73,7 +73,7 @@ fn find_configs() -> Option<PathBuf> {
         let local_config = config_dir.join("Comtrya.yaml");
 
         if local_config.is_file() {
-            debug!("Comtrya.yaml found in users config directory");
+            warn!("Comtrya.yaml found in users config directory");
             return Some(local_config);
         }
         trace!("No Comtrya.yaml found in users config directory");


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?
Some errors were being logged as debug and not as an error.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?
Errors should be logged as errors.

## What is the motivation / use case for changing the behavior?
See issue #247 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: macOS 14.5
