### PR TITLE
Detect if users already exists instead of failing. Fixes #431

### DIFF
--- a/lib/src/actions/user/add.rs
+++ b/lib/src/actions/user/add.rs
@@ -5,6 +5,8 @@ use crate::contexts::Contexts;
 use crate::manifests::Manifest;
 use crate::steps::Step;
 use std::ops::Deref;
+
+#[cfg(unix)]
 use tracing::debug;
 
 pub type UserAdd = User;
@@ -18,13 +20,17 @@ impl Action for UserAdd {
         let mut atoms: Vec<Step> = vec![];
 
         if variant.username.is_empty() {
-            return Ok(atoms)
+            return Ok(atoms);
         }
 
+        #[cfg(unix)]
         match uzers::get_user_by_name(&variant.username) {
             Some(_user) => debug!(message = "User already exists", username = ?variant.username),
-            None       => atoms.append(&mut provider.add_user(&variant)?)
+            None => atoms.append(&mut provider.add_user(&variant)?),
         }
+
+        #[cfg(not(unix))]
+        atoms.append(&mut provider.add_user(&variant)?);
 
         Ok(atoms)
     }

--- a/lib/src/actions/user/add.rs
+++ b/lib/src/actions/user/add.rs
@@ -5,6 +5,7 @@ use crate::contexts::Contexts;
 use crate::manifests::Manifest;
 use crate::steps::Step;
 use std::ops::Deref;
+use tracing::debug;
 
 pub type UserAdd = User;
 
@@ -16,7 +17,14 @@ impl Action for UserAdd {
 
         let mut atoms: Vec<Step> = vec![];
 
-        atoms.append(&mut provider.add_user(&variant)?);
+        if variant.username.is_empty() {
+            return Ok(atoms)
+        }
+
+        match uzers::get_user_by_name(&variant.username) {
+            Some(_user) => debug!(message = "User already exists", username = ?variant.username),
+            None       => atoms.append(&mut provider.add_user(&variant)?)
+        }
 
         Ok(atoms)
     }


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?
Action `user.add` fails if the user already exists.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
```yaml
actions:
  - action: user.add
    fullname: Test User
    home_dir: /home/test
    username: test
    shell: /bin/sh
```

## What is the expected behavior?
Pass without fail if user already exists.

## What is the motivation / use case for changing the behavior?
Should not be marked as a failing result.

## Please tell us about your environment:

Version (`comtrya --version`): ccdf5e1
Operating system: FreeBSD 14
