### PR TITLE
intial code for feature for local package installs

### DIFF
--- a/docs/src/packages.md
+++ b/docs/src/packages.md
@@ -30,13 +30,15 @@ Some package manager providers can implement a `bootstrap` method that will auto
 
 ## package.install
 
-| Key        | Type   | Optional | Description                                    |
-|:-----------|:-------|:---------|:-----------------------------------------------|
-| action     | string | no       | `package.install`                              |
-| name       | string | no       | name of target package                         |
-| list       | list   | yes      | list of multiple packages                      |
-| provider   | string | yes      | Specify package provider                       |
-| repository | string | yes      | specific repository for a provider and package |
+| Key        | Type   | Optional | Description                                                                        |
+|:-----------|:-------|:---------|:-----------------------------------------------------------------------------------|
+| action     | string | no       | `package.install`                                                                  |
+| name       | string | no       | name of target package                                                             |
+| list       | list   | yes      | list of multiple packages                                                          |
+| provider   | string | yes      | Specify package provider                                                           |
+| repository | string | yes      | specific repository for a provider and package                                     |
+| file       | bool   | yes      | Specify that package is a local package on the file system.                        |
+|            |        |          | Default value is `false`                                                           |
 
 
 ### Example
@@ -62,4 +64,21 @@ Some package manager providers can implement a `bootstrap` method that will auto
   name: blox
   provider: homebrew
   repository: cueblox/tap
+```
+
+### Local package install support
+
+Some package providers allow for the ability to install a package from the local file system. An example of this would be `.pkg` files that can be utilized with FreeBSD's package manager `pkg`. As of this time, it requires that the file property be set in the action's definition.
+
+List of supported package providers:
+- pkg (FreeBSD)
+
+If you would like to have this feature supported on another package provider, please open an issue at the [comtrya github](https://github.com/comtrya/comtrya).
+
+#### Example
+
+```
+- action: package.instal
+  name: /some/path/to/file/nano-8.1.pkg
+  file: true
 ```

--- a/lib/src/actions/package/install.rs
+++ b/lib/src/actions/package/install.rs
@@ -1,3 +1,4 @@
+use super::providers::PackageProviders;
 use super::Package;
 use super::PackageVariant;
 use crate::actions::Action;
@@ -6,6 +7,7 @@ use crate::manifests::Manifest;
 use crate::steps::Step;
 use anyhow::anyhow;
 use std::ops::Deref;
+use tracing::debug;
 use tracing::span;
 
 pub type PackageInstall = Package;
@@ -32,6 +34,18 @@ impl Action for PackageInstall {
                     "Package Provider, {}, isn't available. Skipping action",
                     provider.name()
                 ));
+            }
+
+            if variant.file {
+                match variant.provider {
+                    PackageProviders::BsdPkg => debug!("Will attempt to install from local file."),
+                    _ => {
+                        return Err(anyhow!(
+                        "Package Provider, {}, isn't capabale of local file installs. Skipping action.",
+                        provider.name()
+                    ));
+                    }
+                }
             }
 
             atoms.append(&mut provider.bootstrap());

--- a/lib/src/actions/package/mod.rs
+++ b/lib/src/actions/package/mod.rs
@@ -32,6 +32,9 @@ pub struct Package {
 
     #[serde(default)]
     variants: HashMap<os_info::Type, PackageVariant>,
+
+    #[serde(default)]
+    file: bool,
 }
 
 #[derive(JsonSchema, Clone, Debug, Default, Serialize, Deserialize)]
@@ -46,6 +49,9 @@ pub struct PackageVariant {
 
     #[serde(default)]
     extra_args: Vec<String>,
+
+    #[serde(default)]
+    file: bool,
 }
 
 impl PackageVariant {
@@ -71,6 +77,7 @@ impl From<&Package> for PackageVariant {
                 list: package.list.clone(),
                 provider: package.provider.clone(),
                 extra_args: package.extra_args.clone(),
+                file: package.file.clone(),
             };
         };
 
@@ -84,6 +91,7 @@ impl From<&Package> for PackageVariant {
             list: package.list.clone(),
             provider: variant.provider.clone(),
             extra_args: variant.extra_args.clone(),
+            file: package.file.clone(),
         };
 
         if variant.name.is_some() {

--- a/lib/src/actions/package/providers/bsdpkg.rs
+++ b/lib/src/actions/package/providers/bsdpkg.rs
@@ -62,6 +62,23 @@ impl PackageProvider for BsdPkg {
     }
 
     fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+        if package.file {
+            return Ok(vec![Step {
+                atom: Box::new(Exec {
+                    command: String::from("/usr/sbin/pkg"),
+                    arguments: vec![String::from("add")]
+                        .into_iter()
+                        .chain(package.extra_args.clone())
+                        .chain(package.packages())
+                        .collect(),
+                    privileged: true,
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            }]);
+        }
+
         Ok(vec![
             Step {
                 atom: Box::new(Exec {

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -72,6 +72,7 @@ mod test {
             list: vec![],
             extra_args: vec![],
             provider: PackageProviders::Zypper,
+						file: false,
         });
 
         assert_eq!(steps.unwrap().len(), 1);

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -72,7 +72,7 @@ mod test {
             list: vec![],
             extra_args: vec![],
             provider: PackageProviders::Zypper,
-						file: false,
+            file: false,
         });
 
         assert_eq!(steps.unwrap().len(), 1);


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [x] documentation addition

## What is the current behaviour?
Package providers are not able to utilize local package files (such as `.deb` for apt and `.pkg` for FreeBSD's pkg) with a system's package manager.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
Not a bug.

## What is the expected behavior?
For this PR. Just to implement the first package provider, FreeBSD's pkg, with this feature.

Here is a sample manifest:
```
actions:
  - action: package.install
    name: ./examples/test/nano-8.1.pkg
    file: true    
```

As of this PR, true will be required. I will create an issue for creating the ability to detect if its a file versus not a file.

## What is the motivation / use case for changing the behavior?
See issue #430 

## Please tell us about your environment:

Version (`comtrya --version`): v.0.8.9
Operating system: FreeBSD 14.1
