### PR TITLE
Add a regression test for issue #434

### DIFF
--- a/lib/src/actions/package/providers/aptitude.rs
+++ b/lib/src/actions/package/providers/aptitude.rs
@@ -195,4 +195,30 @@ mod test {
 
         assert_eq!(steps.unwrap().len(), 3);
     }
+
+    #[test]
+    fn test_regression_share_ring() {
+        let aptitude = Aptitude {};
+        let steps = aptitude.add_repository(&PackageRepository {
+            name: String::from("test"),
+            key: Some(RepositoryKey {
+                url: String::from("abc"),
+                fingerprint: Some(String::from("abc")),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let steps = match steps {
+            Ok(s) => s,
+            Err(_) => vec![],
+        };
+
+        if let Some(step) = steps.first() {
+            let exec = step.atom.to_string();
+            assert!(exec.contains(" /usr/share/keyrings/"));
+        } else {
+            assert!(false);
+        }
+    }
 }


### PR DESCRIPTION
Check that `share/keyrings` is correct.

## I'm submitting a

- [ ] bug fix
- [ ] feature
- [ ] documentation addition
- [x] Test addition

## What is the current behaviour?
No regression test for #434 

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?
To have a regression test to catch this kind of issue with a string literal

## What is the motivation / use case for changing the behavior?
Requested in issue #435 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: macOS 14.6.1
