### PR TITLE
Add documentation for status command

### DIFF
--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -45,8 +45,9 @@ Usage: comtrya [OPTIONS] <COMMAND>
 
 Commands:
   apply            Apply manifests
+  status           List manifests status (ALPHA)
   version          Print version information
-  contexts         List available contexts (BETA)
+  contexts         List available contexts
   gen-completions  Auto generate completions
   help             Print this message or the help of the given subcommand(s)
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -13,6 +13,7 @@ The primary command of use will be the apply command, which will apply the actio
 | Command         | Description                                  |
 |:----------------|:---------------------------------------------|
 | apply           | Apply manifests                              |
+| status          | List manifest status                         |
 | version         | Print version information                    |
 | contexts        | List available contexts                      |
 | gen-completions | Auto generate completions                    |
@@ -74,4 +75,20 @@ You can also view the values that these contexts have by passing in a `show-valu
 
 ```
 comtrya contexts --show-values
+```
+
+## Status
+
+Provides an overview of manifests.
+
+```
++-------------------+------------------+
+| Manifest          | Count of Actions |
++======================================+
+| kubectl.krew      | 3                |
+|-------------------+------------------|
+| kubectl.kubesess  | 3                |
+|-------------------+------------------|
+| kdash.kdash       | 1                |
++-------------------+------------------+
 ```


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

## What is the current behaviour?
No documentation or mention exists in the documentation.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?
Some documentation for feature in docs.

## What is the motivation / use case for changing the behavior?
#423 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: macOS 14.6.1
