### PR TITLE
Enable aptitude for local file install

### DIFF
--- a/docs/src/packages.md
+++ b/docs/src/packages.md
@@ -72,6 +72,7 @@ Some package providers allow for the ability to install a package from the local
 
 List of supported package providers:
 - pkg (FreeBSD)
+- aptitude (debian/ubuntu)
 
 If you would like to have this feature supported on another package provider, please open an issue at the [comtrya github](https://github.com/comtrya/comtrya).
 

--- a/lib/src/actions/package/install.rs
+++ b/lib/src/actions/package/install.rs
@@ -39,6 +39,9 @@ impl Action for PackageInstall {
             if variant.file {
                 match variant.provider {
                     PackageProviders::BsdPkg => debug!("Will attempt to install from local file."),
+                    PackageProviders::Aptitude => {
+                        debug!("Will attempt to install from local file.")
+                    }
                     _ => {
                         return Err(anyhow!(
                         "Package Provider, {}, isn't capabale of local file installs. Skipping action.",


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?
Aptitude can not use local files for install.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?
Can use local files for install. These are `.deb` packages.

## What is the motivation / use case for changing the behavior?
#430 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: Debian 12
