### PR TITLE
add summarize implementations to actions

### DIFF
--- a/lib/src/actions/command/run.rs
+++ b/lib/src/actions/command/run.rs
@@ -29,6 +29,10 @@ fn get_cwd() -> String {
 }
 
 impl Action for RunCommand {
+		fn summarize(&self) -> String {
+				format!("Running {} command", self.command)
+		}
+		
     fn plan(&self, _: &Manifest, _: &Contexts) -> anyhow::Result<Vec<Step>> {
         use crate::atoms::command::Exec;
 

--- a/lib/src/actions/command/run.rs
+++ b/lib/src/actions/command/run.rs
@@ -29,10 +29,10 @@ fn get_cwd() -> String {
 }
 
 impl Action for RunCommand {
-		fn summarize(&self) -> String {
-				format!("Running {} command", self.command)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Running {} command", self.command)
+    }
+
     fn plan(&self, _: &Manifest, _: &Contexts) -> anyhow::Result<Vec<Step>> {
         use crate::atoms::command::Exec;
 

--- a/lib/src/actions/directory/copy.rs
+++ b/lib/src/actions/directory/copy.rs
@@ -18,6 +18,10 @@ impl DirectoryAction for DirectoryCopy {}
 
 #[cfg(target_family = "windows")]
 impl Action for DirectoryCopy {
+		fn summarize(&self) -> String {
+				format!("Copying {} to {}", self.from, self.to)
+		}
+		
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: String = self.resolve(manifest, &self.from).display().to_string();
 
@@ -35,6 +39,10 @@ impl Action for DirectoryCopy {
 
 #[cfg(target_family = "unix")]
 impl Action for DirectoryCopy {
+		fn summarize(&self) -> String {
+				format!("Copying {} to {}", self.from, self.to)
+		}
+		
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: String = self.resolve(manifest, &self.from).display().to_string();
 

--- a/lib/src/actions/directory/copy.rs
+++ b/lib/src/actions/directory/copy.rs
@@ -18,10 +18,10 @@ impl DirectoryAction for DirectoryCopy {}
 
 #[cfg(target_family = "windows")]
 impl Action for DirectoryCopy {
-		fn summarize(&self) -> String {
-				format!("Copying {} to {}", self.from, self.to)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Copying {} to {}", self.from, self.to)
+    }
+
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: String = self.resolve(manifest, &self.from).display().to_string();
 
@@ -39,10 +39,10 @@ impl Action for DirectoryCopy {
 
 #[cfg(target_family = "unix")]
 impl Action for DirectoryCopy {
-		fn summarize(&self) -> String {
-				format!("Copying {} to {}", self.from, self.to)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Copying {} to {}", self.from, self.to)
+    }
+
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: String = self.resolve(manifest, &self.from).display().to_string();
 

--- a/lib/src/actions/directory/create.rs
+++ b/lib/src/actions/directory/create.rs
@@ -12,6 +12,10 @@ pub struct DirectoryCreate {
 }
 
 impl Action for DirectoryCreate {
+		fn summarize(&self) -> String {
+				format!("Creating directory {}", self.path)
+		}
+		
     fn plan(&self, _: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![Step {
             atom: Box::new(DirectoryCreateAtom {

--- a/lib/src/actions/directory/create.rs
+++ b/lib/src/actions/directory/create.rs
@@ -12,10 +12,10 @@ pub struct DirectoryCreate {
 }
 
 impl Action for DirectoryCreate {
-		fn summarize(&self) -> String {
-				format!("Creating directory {}", self.path)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Creating directory {}", self.path)
+    }
+
     fn plan(&self, _: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![Step {
             atom: Box::new(DirectoryCreateAtom {

--- a/lib/src/actions/directory/remove.rs
+++ b/lib/src/actions/directory/remove.rs
@@ -18,6 +18,10 @@ impl DirectoryRemove {}
 impl DirectoryAction for DirectoryRemove {}
 
 impl Action for DirectoryRemove {
+		fn summarize(&self) -> String {
+				format!("Removing directory {}", self.target)
+		}
+		
     fn plan(
         &self,
         _manifest: &crate::manifests::Manifest,

--- a/lib/src/actions/directory/remove.rs
+++ b/lib/src/actions/directory/remove.rs
@@ -18,10 +18,10 @@ impl DirectoryRemove {}
 impl DirectoryAction for DirectoryRemove {}
 
 impl Action for DirectoryRemove {
-		fn summarize(&self) -> String {
-				format!("Removing directory {}", self.target)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Removing directory {}", self.target)
+    }
+
     fn plan(
         &self,
         _manifest: &crate::manifests::Manifest,

--- a/lib/src/actions/file/copy.rs
+++ b/lib/src/actions/file/copy.rs
@@ -38,7 +38,7 @@ impl Action for FileCopy {
     fn summarize(&self) -> String {
         format!("Copy file from {} to {}", self.from, self.to)
     }
-		
+
     fn plan(
         &self,
         manifest: &Manifest,

--- a/lib/src/actions/file/copy.rs
+++ b/lib/src/actions/file/copy.rs
@@ -36,8 +36,9 @@ impl FileAction for FileCopy {}
 
 impl Action for FileCopy {
     fn summarize(&self) -> String {
-        format!("copy file from {} to {}", self.from, self.to)
+        format!("Copy file from {} to {}", self.from, self.to)
     }
+		
     fn plan(
         &self,
         manifest: &Manifest,

--- a/lib/src/actions/file/download.rs
+++ b/lib/src/actions/file/download.rs
@@ -29,10 +29,10 @@ impl FileDownload {}
 impl FileAction for FileDownload {}
 
 impl Action for FileDownload {
-		fn summarize(&self) -> String {
-				format!("Downloading file {} to {}", self.from, self.to)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Downloading file {} to {}", self.from, self.to)
+    }
+
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         use crate::atoms::directory::Create as DirCreate;
         use crate::atoms::file::Chmod;

--- a/lib/src/actions/file/download.rs
+++ b/lib/src/actions/file/download.rs
@@ -29,6 +29,10 @@ impl FileDownload {}
 impl FileAction for FileDownload {}
 
 impl Action for FileDownload {
+		fn summarize(&self) -> String {
+				format!("Downloading file {} to {}", self.from, self.to)
+		}
+		
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         use crate::atoms::directory::Create as DirCreate;
         use crate::atoms::file::Chmod;

--- a/lib/src/actions/file/link.rs
+++ b/lib/src/actions/file/link.rs
@@ -117,6 +117,10 @@ impl FileLink {
 impl FileAction for FileLink {}
 
 impl Action for FileLink {
+		fn summarize(&self) -> String {
+				format!("Linking file {} to {}", self.from.clone().unwrap_or(String::from("unknown")), self.to.clone().unwrap_or(String::from("unknown")))
+		}
+		
     fn plan(&self, manifest: &Manifest, _: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: PathBuf = self.resolve(manifest, self.source().as_str())?;
 

--- a/lib/src/actions/file/link.rs
+++ b/lib/src/actions/file/link.rs
@@ -117,10 +117,14 @@ impl FileLink {
 impl FileAction for FileLink {}
 
 impl Action for FileLink {
-		fn summarize(&self) -> String {
-				format!("Linking file {} to {}", self.from.clone().unwrap_or(String::from("unknown")), self.to.clone().unwrap_or(String::from("unknown")))
-		}
-		
+    fn summarize(&self) -> String {
+        format!(
+            "Linking file {} to {}",
+            self.from.clone().unwrap_or(String::from("unknown")),
+            self.to.clone().unwrap_or(String::from("unknown"))
+        )
+    }
+
     fn plan(&self, manifest: &Manifest, _: &Contexts) -> anyhow::Result<Vec<Step>> {
         let from: PathBuf = self.resolve(manifest, self.source().as_str())?;
 

--- a/lib/src/actions/file/remove.rs
+++ b/lib/src/actions/file/remove.rs
@@ -17,6 +17,10 @@ impl FileRemove {}
 impl FileAction for FileRemove {}
 
 impl Action for FileRemove {
+		fn summarize(&self) -> String {
+				format!("Removing file {}", self.target)
+		}
+		
     fn plan(
         &self,
         _: &crate::manifests::Manifest,

--- a/lib/src/actions/file/remove.rs
+++ b/lib/src/actions/file/remove.rs
@@ -17,10 +17,10 @@ impl FileRemove {}
 impl FileAction for FileRemove {}
 
 impl Action for FileRemove {
-		fn summarize(&self) -> String {
-				format!("Removing file {}", self.target)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Removing file {}", self.target)
+    }
+
     fn plan(
         &self,
         _: &crate::manifests::Manifest,

--- a/lib/src/actions/group/add.rs
+++ b/lib/src/actions/group/add.rs
@@ -9,10 +9,10 @@ use std::ops::Deref;
 pub type GroupAdd = Group;
 
 impl Action for GroupAdd {
-		fn summarize(&self) -> String {
-				format!("Creating group {}", self.group_name)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Creating group {}", self.group_name)
+    }
+
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: GroupVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();

--- a/lib/src/actions/group/add.rs
+++ b/lib/src/actions/group/add.rs
@@ -9,6 +9,10 @@ use std::ops::Deref;
 pub type GroupAdd = Group;
 
 impl Action for GroupAdd {
+		fn summarize(&self) -> String {
+				format!("Creating group {}", self.group_name)
+		}
+		
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: GroupVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();

--- a/lib/src/actions/package/install.rs
+++ b/lib/src/actions/package/install.rs
@@ -13,6 +13,10 @@ use tracing::span;
 pub type PackageInstall = Package;
 
 impl Action for PackageInstall {
+		fn summarize(&self) -> String {
+				format!("Installing packages")
+		}
+		
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: PackageVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();

--- a/lib/src/actions/package/install.rs
+++ b/lib/src/actions/package/install.rs
@@ -13,10 +13,10 @@ use tracing::span;
 pub type PackageInstall = Package;
 
 impl Action for PackageInstall {
-		fn summarize(&self) -> String {
-				format!("Installing packages")
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Installing packages")
+    }
+
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: PackageVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();

--- a/lib/src/actions/package/repository.rs
+++ b/lib/src/actions/package/repository.rs
@@ -29,10 +29,10 @@ pub struct RepositoryKey {
 }
 
 impl Action for PackageRepository {
-		fn summarize(&self) -> String {
-				format!("Adding repository {}", self.name)
-		}
-		
+    fn summarize(&self) -> String {
+        format!("Adding repository {}", self.name)
+    }
+
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let box_provider = self.provider.clone().get_provider();
         let provider = box_provider.deref();

--- a/lib/src/actions/package/repository.rs
+++ b/lib/src/actions/package/repository.rs
@@ -29,6 +29,10 @@ pub struct RepositoryKey {
 }
 
 impl Action for PackageRepository {
+		fn summarize(&self) -> String {
+				format!("Adding repository {}", self.name)
+		}
+		
     fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let box_provider = self.provider.clone().get_provider();
         let provider = box_provider.deref();


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?
Actions don't implement a summarize.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?
Provide a summarize summary for actions

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: macOS 14.6.1
