### PR TITLE
Append file name to target if target is a directory

### DIFF
--- a/docs/src/files-and-directories.md
+++ b/docs/src/files-and-directories.md
@@ -53,6 +53,7 @@ This action will download a file.
 | from   | string | no       | source location  |
 | to     | string | no       | destination file |
 
+An alias also exists such that `source` can be used in lieu of `from` and `target` can be used in lieu of `to`.
 
 ### Example
 

--- a/lib/src/actions/file/copy.rs
+++ b/lib/src/actions/file/copy.rs
@@ -86,7 +86,14 @@ impl Action for FileCopy {
         use crate::atoms::directory::Create as DirCreate;
         use crate::atoms::file::{Chmod, Create, SetContents};
 
-        let path = PathBuf::from(&self.to);
+        let mut path = PathBuf::from(&self.to);
+
+        if path.is_dir() {
+            if let Some(file_name) = PathBuf::from(self.from.clone()).file_name() {
+                path = path.join(file_name);
+            }
+        }
+
         let parent = path.clone();
         let mut steps = vec![
             Step {

--- a/lib/src/actions/file/copy.rs
+++ b/lib/src/actions/file/copy.rs
@@ -14,7 +14,10 @@ use tera::Tera;
 
 #[derive(JsonSchema, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FileCopy {
+		#[serde(alias = "source")]
     pub from: String,
+
+		#[serde(alias = "target")]
     pub to: String,
 
     #[serde(default = "default_chmod", deserialize_with = "from_octal")]

--- a/lib/src/actions/file/copy.rs
+++ b/lib/src/actions/file/copy.rs
@@ -14,10 +14,10 @@ use tera::Tera;
 
 #[derive(JsonSchema, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FileCopy {
-		#[serde(alias = "source")]
+    #[serde(alias = "source")]
     pub from: String,
 
-		#[serde(alias = "target")]
+    #[serde(alias = "target")]
     pub to: String,
 
     #[serde(default = "default_chmod", deserialize_with = "from_octal")]


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?
File copy fails when `to` is a directory.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
```
actions:
  - action: file.copy
    from: sample.txt
    to: /tmp/
```

## What is the expected behavior?
This action to pass with comtrya appending the file name to the target

## What is the motivation / use case for changing the behavior?
#315 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: macOS 14.6.1
