### PR TITLE
Copy directory contents if target ends with a trailing slash (/)

### DIFF
--- a/lib/src/actions/directory/copy.rs
+++ b/lib/src/actions/directory/copy.rs
@@ -44,7 +44,11 @@ impl Action for DirectoryCopy {
     }
 
     fn plan(&self, manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
-        let from: String = self.resolve(manifest, &self.from).display().to_string();
+        let mut from: String = self.resolve(manifest, &self.from).display().to_string();
+
+        if self.to.ends_with("/") {
+            from += "/."
+        }
 
         Ok(vec![
             Step {


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

`directory.copy` always copies the entire directory.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

With this PR, if I specify:

```yaml
actions:
  - action: directory.copy
    from: /tmp/a
    to: /tmp/b/
```

then the directory  `/tmp/b/a` will not exist, but all the contents of `/tmp/a` will be in `/tmp/b/...`

## What is the expected behavior?

After running the above manifest:

```sh
$ find /tmp/a
/tmp/a/.hidden.txt
/tmp/a/doc.txt

$ find /tmp/b
/tmp/b/.hidden.txt
/tmp/b/doc.txt
```

## What is the motivation / use case for changing the behavior?

Users should be able to copy only the contents of a directory, and not the directory itself.

## Please tell us about your environment:

Version (`comtrya --version`): comtrya 0.8.9
Operating system: FreeBSD 14