### PR TITLE
Deploy mdbook only if owner is comtrya.

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -32,16 +32,33 @@ jobs:
       MDBOOK_VERSION: 0.4.36
     steps:
       - uses: actions/checkout@v4
+      - name: Cache mdbook output
+        uses: actions/cache@v2
+        with:
+          path: ./docs
+          key: cache-mdbook
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
+      - name: Build with mdBook
+        run: mdbook build ./docs/
+
+  # Upload job
+  upload:
+    if: ${{ github.repository_owner == 'comtrya' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore cached docs
+        id: cache-mdbook-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ./docs
+          key: cache-mdbook
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-      - name: Build with mdBook
-        run: mdbook build ./docs/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -49,6 +66,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: ${{ github.repository_owner == 'comtrya' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [] feature
- [ ] documentation addition

## What is the current behaviour?

The deploy mdbook workflow fails in my fork because I don't have permission to publish.

It would be great to see that all tests pass / fail when looking at my fork commit history without having to account for the deploy workflow always failing.