### PR TITLE
Add a check over supplied manifests for paths

### DIFF
--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -13,7 +13,8 @@ use tracing::{debug, error, info, instrument, span, trace, warn};
 
 #[derive(Parser, Debug)]
 pub(crate) struct Apply {
-    /// Run a subset of your manifests, comma separated list
+    /// Run a subset of your manifests, comma separated list.
+    /// This should be a list of manifest names. No paths.
     #[arg(short, long, value_delimiter = ',')]
     manifests: Vec<String>,
 

--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -31,7 +31,9 @@ impl Apply {
     fn manifest_path(&self, runtime: &Runtime) -> anyhow::Result<PathBuf> {
         for manifest in &self.manifests {
             if manifest.contains(std::path::MAIN_SEPARATOR) {
-                return Err(anyhow::anyhow!("Found a path, expected only names in the manifests list!"));
+                return Err(anyhow::anyhow!(
+                    "Found a path, expected only names in the manifests list!"
+                ));
             }
         }
 

--- a/app/src/commands/apply.rs
+++ b/app/src/commands/apply.rs
@@ -28,6 +28,12 @@ pub(crate) struct Apply {
 
 impl Apply {
     fn manifest_path(&self, runtime: &Runtime) -> anyhow::Result<PathBuf> {
+        for manifest in &self.manifests {
+            if manifest.contains(std::path::MAIN_SEPARATOR) {
+                return Err(anyhow::anyhow!("Found a path, expected only names in the manifests list!"));
+            }
+        }
+
         let first_manifest_path = runtime.config.manifest_paths.first().ok_or_else(|| {
             anyhow::anyhow!(
                 "No manifest paths found in config file, please add at least one path to your manifests"


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?
When a lists of manifests name are passed in using the `-m` option, they are not checked to see if they are paths.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

Using the samples in the repos `examples`, run the following

```shell
comtrya apply -m examples/command/run
```

With how has been, it is easy to assume the above is valid, when it is not.

## What is the expected behavior?
Fail with output suggesting that names, not paths are expected.
Also, addition information in the apply options help dialog.

## What is the motivation / use case for changing the behavior?
#470 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: macOS 15
