### PR TITLE
Fix tests for user and group providers on FreeBSD.

### DIFF
--- a/lib/src/actions/group/providers/freebsd.rs
+++ b/lib/src/actions/group/providers/freebsd.rs
@@ -30,12 +30,16 @@ impl GroupProvider for FreeBSDGroupProvider {
 #[cfg(target_os = "freebsd")]
 #[cfg(test)]
 mod test {
-    use crate::actions::group::*;
+    use crate::actions::group::providers::{FreeBSDGroupProvider, GroupProvider};
+    use crate::actions::group::GroupVariant;
 
     #[test]
     fn test_add_group() {
         let group_provider = FreeBSDGroupProvider {};
-        let steps = user_provider.add_user(&GroupVariant { group_name: test });
+        let steps = group_provider.add_group(&GroupVariant {
+            group_name: String::from("test"),
+            ..Default::default()
+        });
 
         assert_eq!(steps.len(), 1);
     }
@@ -43,8 +47,9 @@ mod test {
     #[test]
     fn test_add_group_no_group_name() {
         let group_provider = FreeBSDGroupProvider {};
-        let steps = group_provider.add_user(&GroupVariant {
+        let steps = group_provider.add_group(&GroupVariant {
             // empty for test purposes
+            ..Default::default()
         });
 
         assert_eq!(steps.len(), 0);

--- a/lib/src/actions/user/providers/freebsd.rs
+++ b/lib/src/actions/user/providers/freebsd.rs
@@ -122,7 +122,7 @@ mod test {
             ..Default::default()
         });
 
-        assert_eq!(steps.len(), 1);
+        assert_eq!(steps.unwrap().len(), 1);
     }
 
     #[test]
@@ -137,7 +137,7 @@ mod test {
             ..Default::default()
         });
 
-        assert_eq!(steps.len(), 0);
+        assert_eq!(steps.unwrap().len(), 0);
     }
 
     #[test]
@@ -149,7 +149,7 @@ mod test {
             ..Default::default()
         });
 
-        assert_eq!(steps.len(), 2);
+        assert_eq!(steps.unwrap().len(), 2);
     }
 
     #[test]
@@ -164,6 +164,6 @@ mod test {
             ..Default::default()
         });
 
-        assert_eq!(steps.len(), 2);
+        assert_eq!(steps.unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Unable to run `cargo test` due to compiler errors.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

Run `cargo test` on FreeBSD.

## What is the expected behavior?

Should see testing output.

## Please tell us about your environment:

Version (`comtrya --version`): 73b462d
Operating system: FreeBSD 14
