### PR TITLE
Feature: Support doas (sudo alternative). Fixes #429

### DIFF
--- a/docs/src/privileged.md
+++ b/docs/src/privileged.md
@@ -19,6 +19,5 @@ privilege escalation. A more generic way to write the above action would be to u
 ```
 - action: command.run
   command: whoami
-  sudo: true
   privileged: true
 ```


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

Only `sudo` is searched for. `doas` is a popular alternative.

## What is the expected behavior?

Running steps with `privileged: true` should work if only `doas` is installed. Fixes #429

In this version of the PR, `sudo` is searched for first.

## What is the motivation / use case for changing the behavior?

To support a safer implementation of `sudo`.

## Please tell us about your environment:

Version (`comtrya --version`): 73b462d
Operating system: FreeBSD 14
