### PR TITLE
Add documentation for file command behaviour

### DIFF
--- a/docs/src/files-and-directories.md
+++ b/docs/src/files-and-directories.md
@@ -6,6 +6,16 @@
 - file.remove
 - directory.copy
 
+## Note
+The following commands expect the `from`/`source` to point to files/directories which are themselves under a "files" directory.
+This is a restriction so that comtrya knows not to parse any .yaml file e.g. a config for a different tool as a manifest.
+To see how it works check the [examples](https://github.com/comtrya/comtrya/tree/main/examples/file) 
+
+- file.link
+- file.copy
+- directory.copy
+
+
 ## file.copy
 
 Action used to copy a file from one location to another.


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

As discussed in #474 I added a note to the file command documentation to explain the need for the "files" directory. 

Note: There is also discussion on changing the behaviour here: #96 

@rawkode @martintc Please tell me if you expected it in a different way as you probably know best how you wanted to structure your documentation
