### PR TITLE
feature: Privilege providers

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -118,7 +118,6 @@ fn main() -> anyhow::Result<()> {
 
     // Run Context Providers
     let contexts = build_contexts(&config);
-
     let runtime = Runtime {
         args,
         config,

--- a/lib/src/actions/command/run.rs
+++ b/lib/src/actions/command/run.rs
@@ -33,8 +33,16 @@ impl Action for RunCommand {
         format!("Running {} command", self.command)
     }
 
-    fn plan(&self, _: &Manifest, _: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn plan(&self, _: &Manifest, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         use crate::atoms::command::Exec;
+
+        let privilege_provider = contexts
+            .get("privilege")
+            .unwrap()
+            .first_key_value()
+            .unwrap()
+            .1;
+        tracing::debug!("{:#?}", privilege_provider);
 
         Ok(vec![Step {
             atom: Box::new(Exec {
@@ -42,6 +50,7 @@ impl Action for RunCommand {
                 arguments: self.args.clone(),
                 privileged: self.privileged,
                 working_dir: Some(self.dir.clone()),
+                privilege_provider: privilege_provider.to_string().clone(),
                 ..Default::default()
             }),
             initializers: vec![],

--- a/lib/src/actions/group/add.rs
+++ b/lib/src/actions/group/add.rs
@@ -13,14 +13,14 @@ impl Action for GroupAdd {
         format!("Creating group {}", self.group_name)
     }
 
-    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn plan(&self, _manifest: &Manifest, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: GroupVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();
         let provider = box_provider.deref();
 
         let mut atoms: Vec<Step> = vec![];
 
-        atoms.append(&mut provider.add_group(&variant));
+        atoms.append(&mut provider.add_group(&variant, &contexts));
 
         Ok(atoms)
     }

--- a/lib/src/actions/group/providers/freebsd.rs
+++ b/lib/src/actions/group/providers/freebsd.rs
@@ -37,14 +37,19 @@ impl GroupProvider for FreeBSDGroupProvider {
 mod test {
     use crate::actions::group::providers::{FreeBSDGroupProvider, GroupProvider};
     use crate::actions::group::GroupVariant;
+    use crate::contexts::Contexts;
 
     #[test]
     fn test_add_group() {
         let group_provider = FreeBSDGroupProvider {};
-        let steps = group_provider.add_group(&GroupVariant {
-            group_name: String::from("test"),
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = group_provider.add_group(
+            &GroupVariant {
+                group_name: String::from("test"),
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.len(), 1);
     }
@@ -52,10 +57,14 @@ mod test {
     #[test]
     fn test_add_group_no_group_name() {
         let group_provider = FreeBSDGroupProvider {};
-        let steps = group_provider.add_group(&GroupVariant {
-            // empty for test purposes
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = group_provider.add_group(
+            &GroupVariant {
+                // empty for test purposes
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.len(), 0);
     }

--- a/lib/src/actions/group/providers/linux.rs
+++ b/lib/src/actions/group/providers/linux.rs
@@ -51,7 +51,7 @@ mod test {
     #[test]
     fn test_add_group() {
         let group_provider = LinuxGroupProvider {};
-        let context = Contexts::default();
+        let contexts = Contexts::default();
         let steps = group_provider.add_group(
             &GroupVariant {
                 group_name: String::from("test"),
@@ -66,7 +66,7 @@ mod test {
     #[test]
     fn test_add_group_no_group_name() {
         let group_provider = LinuxGroupProvider {};
-        let context = Contexts::default();
+        let contexts = Contexts::default();
         let steps = group_provider.add_group(
             &GroupVariant {
                 // empty for test purposes

--- a/lib/src/actions/group/providers/linux.rs
+++ b/lib/src/actions/group/providers/linux.rs
@@ -46,14 +46,19 @@ impl GroupProvider for LinuxGroupProvider {
 mod test {
     use crate::actions::group::providers::{GroupProvider, LinuxGroupProvider};
     use crate::actions::group::GroupVariant;
+    use crate::contexts::Contexts;
 
     #[test]
     fn test_add_group() {
         let group_provider = LinuxGroupProvider {};
-        let steps = group_provider.add_group(&GroupVariant {
-            group_name: String::from("test"),
-            ..Default::default()
-        });
+        let context = Contexts::default();
+        let steps = group_provider.add_group(
+            &GroupVariant {
+                group_name: String::from("test"),
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.len(), 1);
     }
@@ -61,10 +66,14 @@ mod test {
     #[test]
     fn test_add_group_no_group_name() {
         let group_provider = LinuxGroupProvider {};
-        let steps = group_provider.add_group(&GroupVariant {
-            // empty for test purposes
-            ..Default::default()
-        });
+        let context = Contexts::default();
+        let steps = group_provider.add_group(
+            &GroupVariant {
+                // empty for test purposes
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.len(), 0);
     }

--- a/lib/src/actions/group/providers/macos.rs
+++ b/lib/src/actions/group/providers/macos.rs
@@ -1,6 +1,7 @@
 use super::GroupProvider;
+use crate::contexts::Contexts;
 use crate::steps::Step;
-use crate::{actions::group::GroupVariant, atoms::command::Exec};
+use crate::{actions::group::GroupVariant, atoms::command::Exec, utilities};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use which::which;
@@ -9,7 +10,7 @@ use which::which;
 pub struct MacOsGroupProvider {}
 
 impl GroupProvider for MacOsGroupProvider {
-    fn add_group(&self, group: &GroupVariant) -> Vec<Step> {
+    fn add_group(&self, group: &GroupVariant, contexts: &Contexts) -> Vec<Step> {
         let cli = match which("dscl") {
             Ok(c) => c,
             Err(_) => {
@@ -32,11 +33,15 @@ impl GroupProvider for MacOsGroupProvider {
             group_creation_string.to_owned(),
         ];
 
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
+
         vec![Step {
             atom: Box::new(Exec {
                 command: cli.display().to_string(),
                 arguments: args.into_iter().collect(),
                 privileged: true,
+                privilege_provider: privilege_provider.clone(),
                 ..Default::default()
             }),
             initializers: vec![],
@@ -50,14 +55,19 @@ impl GroupProvider for MacOsGroupProvider {
 mod test {
     use crate::actions::group::providers::{GroupProvider, MacOsGroupProvider};
     use crate::actions::group::GroupVariant;
+    use crate::contexts::Contexts;
 
     #[test]
     fn test_add_group() {
         let group_provider = MacOsGroupProvider {};
-        let steps = group_provider.add_group(&GroupVariant {
-            group_name: String::from("test"),
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = group_provider.add_group(
+            &GroupVariant {
+                group_name: String::from("test"),
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.len(), 1);
     }
@@ -65,10 +75,14 @@ mod test {
     #[test]
     fn test_add_group_no_group_name() {
         let group_provider = MacOsGroupProvider {};
-        let steps = group_provider.add_group(&GroupVariant {
-            // empty for test purposes
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = group_provider.add_group(
+            &GroupVariant {
+                // empty for test purposes
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.len(), 0);
     }

--- a/lib/src/actions/group/providers/mod.rs
+++ b/lib/src/actions/group/providers/mod.rs
@@ -4,8 +4,10 @@ use crate::steps::Step;
 mod none;
 use self::{freebsd::FreeBSDGroupProvider, none::NoneGroupProvider};
 use super::GroupVariant;
+use crate::contexts::Contexts;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
 mod freebsd;
 mod linux;
 use self::linux::LinuxGroupProvider;
@@ -58,5 +60,5 @@ impl Default for GroupProviders {
 }
 
 pub trait GroupProvider {
-    fn add_group(&self, group: &GroupVariant) -> Vec<Step>;
+    fn add_group(&self, group: &GroupVariant, contexts: &Contexts) -> Vec<Step>;
 }

--- a/lib/src/actions/group/providers/none.rs
+++ b/lib/src/actions/group/providers/none.rs
@@ -1,5 +1,6 @@
 use super::GroupProvider;
 use crate::actions::group::GroupVariant;
+use crate::contexts::Contexts;
 use crate::steps::Step;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -8,7 +9,7 @@ use tracing::warn;
 pub struct NoneGroupProvider {}
 
 impl GroupProvider for NoneGroupProvider {
-    fn add_group(&self, _group: &GroupVariant) -> Vec<Step> {
+    fn add_group(&self, _group: &GroupVariant, _contexts: &Contexts) -> Vec<Step> {
         warn!("This system does not have a provider for groups");
         vec![]
     }

--- a/lib/src/actions/package/install.rs
+++ b/lib/src/actions/package/install.rs
@@ -33,7 +33,7 @@ impl Action for PackageInstall {
 
         // If the provider isn't available, see if we can bootstrap it
         if !provider.available() {
-            if provider.bootstrap().is_empty() {
+            if provider.bootstrap(&context).is_empty() {
                 return Err(anyhow!(
                     "Package Provider, {}, isn't available. Skipping action",
                     provider.name()
@@ -55,7 +55,7 @@ impl Action for PackageInstall {
                 }
             }
 
-            atoms.append(&mut provider.bootstrap());
+            atoms.append(&mut provider.bootstrap(&context));
         }
 
         atoms.append(&mut provider.install(&variant, &context)?);

--- a/lib/src/actions/package/install.rs
+++ b/lib/src/actions/package/install.rs
@@ -14,10 +14,10 @@ pub type PackageInstall = Package;
 
 impl Action for PackageInstall {
     fn summarize(&self) -> String {
-        format!("Installing packages")
+        "Installing packages".to_string()
     }
 
-    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn plan(&self, _manifest: &Manifest, context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: PackageVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();
         let provider = box_provider.deref();
@@ -58,7 +58,7 @@ impl Action for PackageInstall {
             atoms.append(&mut provider.bootstrap());
         }
 
-        atoms.append(&mut provider.install(&variant)?);
+        atoms.append(&mut provider.install(&variant, &context)?);
 
         span.exit();
 

--- a/lib/src/actions/package/providers/aptitude.rs
+++ b/lib/src/actions/package/providers/aptitude.rs
@@ -60,10 +60,13 @@ impl PackageProvider for Aptitude {
         false
     }
 
-    fn add_repository(&self, repository: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, repository: &PackageRepository, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         let mut steps: Vec<Step> = vec![];
 
         let mut signed_by = String::from("");
+
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
 
         if repository.key.is_some() {
             // .unwrap() is safe here because we checked for key.is_some() above
@@ -80,6 +83,7 @@ impl PackageProvider for Aptitude {
                     arguments: vec![String::from("-o"), key_path, key.url],
                     environment: self.env(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],
@@ -102,6 +106,7 @@ impl PackageProvider for Aptitude {
                     ],
                     environment: self.env(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],
@@ -113,6 +118,7 @@ impl PackageProvider for Aptitude {
                     arguments: vec![String::from("update")],
                     environment: self.env(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],

--- a/lib/src/actions/package/providers/aptitude.rs
+++ b/lib/src/actions/package/providers/aptitude.rs
@@ -36,7 +36,10 @@ impl PackageProvider for Aptitude {
         }
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, contexts: &Contexts) -> Vec<Step> {
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
+
         vec![Step {
             atom: Box::new(Exec {
                 command: String::from("apt"),
@@ -49,6 +52,7 @@ impl PackageProvider for Aptitude {
                 ],
                 environment: self.env(),
                 privileged: true,
+                privilege_provider: privilege_provider.clone(),
                 ..Default::default()
             }),
             initializers: vec![],

--- a/lib/src/actions/package/providers/aptitude.rs
+++ b/lib/src/actions/package/providers/aptitude.rs
@@ -60,7 +60,11 @@ impl PackageProvider for Aptitude {
         false
     }
 
-    fn add_repository(&self, repository: &PackageRepository, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        repository: &PackageRepository,
+        contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         let mut steps: Vec<Step> = vec![];
 
         let mut signed_by = String::from("");
@@ -159,6 +163,7 @@ impl PackageProvider for Aptitude {
 #[cfg(test)]
 mod test {
     use crate::actions::package::repository::RepositoryKey;
+    use crate::contexts::Contexts;
 
     use super::*;
 
@@ -169,10 +174,14 @@ mod test {
     #[test]
     fn test_add_repository_without_key() {
         let aptitude = Aptitude {};
-        let steps = aptitude.add_repository(&PackageRepository {
-            name: String::from("test"),
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = aptitude.add_repository(
+            &PackageRepository {
+                name: String::from("test"),
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 2);
     }
@@ -180,14 +189,18 @@ mod test {
     #[test]
     fn test_add_repository_with_key() {
         let aptitude = Aptitude {};
-        let steps = aptitude.add_repository(&PackageRepository {
-            name: String::from("test"),
-            key: Some(RepositoryKey {
-                url: String::from("abc"),
+        let contexts = Contexts::default();
+        let steps = aptitude.add_repository(
+            &PackageRepository {
+                name: String::from("test"),
+                key: Some(RepositoryKey {
+                    url: String::from("abc"),
+                    ..Default::default()
+                }),
                 ..Default::default()
-            }),
-            ..Default::default()
-        });
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 3);
     }
@@ -195,15 +208,19 @@ mod test {
     #[test]
     fn test_add_repository_with_key_and_fingerprint() {
         let aptitude = Aptitude {};
-        let steps = aptitude.add_repository(&PackageRepository {
-            name: String::from("test"),
-            key: Some(RepositoryKey {
-                url: String::from("abc"),
-                fingerprint: Some(String::from("abc")),
+        let contexts = Contexts::default();
+        let steps = aptitude.add_repository(
+            &PackageRepository {
+                name: String::from("test"),
+                key: Some(RepositoryKey {
+                    url: String::from("abc"),
+                    fingerprint: Some(String::from("abc")),
+                    ..Default::default()
+                }),
                 ..Default::default()
-            }),
-            ..Default::default()
-        });
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 3);
     }
@@ -211,15 +228,19 @@ mod test {
     #[test]
     fn test_regression_share_ring() {
         let aptitude = Aptitude {};
-        let steps = aptitude.add_repository(&PackageRepository {
-            name: String::from("test"),
-            key: Some(RepositoryKey {
-                url: String::from("abc"),
-                fingerprint: Some(String::from("abc")),
+        let contexts = Contexts::default();
+        let steps = aptitude.add_repository(
+            &PackageRepository {
+                name: String::from("test"),
+                key: Some(RepositoryKey {
+                    url: String::from("abc"),
+                    fingerprint: Some(String::from("abc")),
+                    ..Default::default()
+                }),
                 ..Default::default()
-            }),
-            ..Default::default()
-        });
+            },
+            &contexts,
+        );
 
         let steps = match steps {
             Ok(s) => s,

--- a/lib/src/actions/package/providers/bsdpkg.rs
+++ b/lib/src/actions/package/providers/bsdpkg.rs
@@ -52,7 +52,11 @@ impl PackageProvider for BsdPkg {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        _: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/bsdpkg.rs
+++ b/lib/src/actions/package/providers/bsdpkg.rs
@@ -1,9 +1,10 @@
 use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
+use crate::contexts::Contexts;
 use crate::steps::finalizers::FlowControl::StopIf;
 use crate::steps::finalizers::OutputContains;
 use crate::steps::Step;
-use crate::{actions::package::PackageVariant, atoms::command::Exec};
+use crate::{actions::package::PackageVariant, atoms::command::Exec, utilities};
 use serde::{Deserialize, Serialize};
 use tracing::{instrument, warn};
 use which::which;
@@ -61,7 +62,10 @@ impl PackageProvider for BsdPkg {
         Ok(package.packages())
     }
 
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+    fn install(&self, package: &PackageVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
+
         if package.file {
             return Ok(vec![Step {
                 atom: Box::new(Exec {
@@ -72,6 +76,7 @@ impl PackageProvider for BsdPkg {
                         .chain(package.packages())
                         .collect(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],
@@ -89,6 +94,7 @@ impl PackageProvider for BsdPkg {
                         .chain(package.packages())
                         .collect(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],
@@ -103,6 +109,7 @@ impl PackageProvider for BsdPkg {
                         .chain(package.packages())
                         .collect(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],

--- a/lib/src/actions/package/providers/bsdpkg.rs
+++ b/lib/src/actions/package/providers/bsdpkg.rs
@@ -34,13 +34,17 @@ impl PackageProvider for BsdPkg {
     }
 
     #[instrument(name = "bootstrap", level = "info", skip(self))]
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, contexts: &Contexts) -> Vec<Step> {
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
+
         vec![Step {
             atom: Box::new(Exec {
                 command: String::from("/usr/sbin/pkg"),
                 arguments: vec![String::from("bootstrap")],
                 environment: self.env(),
                 privileged: true,
+                privilege_provider: privilege_provider.clone(),
                 ..Default::default()
             }),
             initializers: vec![],

--- a/lib/src/actions/package/providers/bsdpkg.rs
+++ b/lib/src/actions/package/providers/bsdpkg.rs
@@ -52,7 +52,7 @@ impl PackageProvider for BsdPkg {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/dnf.rs
+++ b/lib/src/actions/package/providers/dnf.rs
@@ -27,7 +27,10 @@ impl PackageProvider for Dnf {
         }
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, contexts: &Contexts) -> Vec<Step> {
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
+
         vec![Step {
             atom: Box::new(Exec {
                 command: String::from("yum"),
@@ -37,6 +40,7 @@ impl PackageProvider for Dnf {
                     String::from("dnf"),
                 ],
                 privileged: true,
+                privilege_provider: privilege_provider.clone(),
                 ..Default::default()
             }),
             initializers: vec![],

--- a/lib/src/actions/package/providers/dnf.rs
+++ b/lib/src/actions/package/providers/dnf.rs
@@ -48,8 +48,11 @@ impl PackageProvider for Dnf {
         false
     }
 
-    fn add_repository(&self, repository: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, repository: &PackageRepository, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         let mut steps: Vec<Step> = vec![];
+
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
 
         if repository.key.is_some() {
             // .unwrap() is safe here because we checked for key presence above
@@ -60,6 +63,7 @@ impl PackageProvider for Dnf {
                     command: String::from("rpm"),
                     arguments: vec![String::from("--import"), key.url],
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],
@@ -78,6 +82,7 @@ impl PackageProvider for Dnf {
                         repository.name.clone(),
                     ],
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],
@@ -92,6 +97,7 @@ impl PackageProvider for Dnf {
                         String::from("--refresh"),
                     ],
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],

--- a/lib/src/actions/package/providers/dnf.rs
+++ b/lib/src/actions/package/providers/dnf.rs
@@ -48,7 +48,11 @@ impl PackageProvider for Dnf {
         false
     }
 
-    fn add_repository(&self, repository: &PackageRepository, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        repository: &PackageRepository,
+        contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         let mut steps: Vec<Step> = vec![];
 
         let privilege_provider =
@@ -141,17 +145,22 @@ impl PackageProvider for Dnf {
 #[cfg(test)]
 mod test {
     use crate::actions::package::{providers::PackageProviders, repository::RepositoryKey};
+    use crate::contexts::Contexts;
 
     use super::*;
 
     #[test]
     fn test_add_repository_without_key() {
         let dnf = Dnf {};
-        let steps = dnf.add_repository(&PackageRepository {
-            name: String::from("test"),
-            provider: PackageProviders::Dnf,
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = dnf.add_repository(
+            &PackageRepository {
+                name: String::from("test"),
+                provider: PackageProviders::Dnf,
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 2);
     }
@@ -159,14 +168,18 @@ mod test {
     #[test]
     fn test_repository_with_key() {
         let dnf = Dnf {};
-        let steps = dnf.add_repository(&PackageRepository {
-            name: String::from("test"),
-            key: Some(RepositoryKey {
-                url: String::from("abc"),
-                ..Default::default()
-            }),
-            provider: PackageProviders::Dnf,
-        });
+        let contexts = Contexts::default();
+        let steps = dnf.add_repository(
+            &PackageRepository {
+                name: String::from("test"),
+                key: Some(RepositoryKey {
+                    url: String::from("abc"),
+                    ..Default::default()
+                }),
+                provider: PackageProviders::Dnf,
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 3);
     }

--- a/lib/src/actions/package/providers/homebrew.rs
+++ b/lib/src/actions/package/providers/homebrew.rs
@@ -1,7 +1,8 @@
 use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
+use crate::contexts::Contexts;
 use crate::steps::Step;
-use crate::{actions::package::PackageVariant, atoms::command::Exec};
+use crate::{actions::package::PackageVariant, atoms::command::Exec, utilities};
 use serde::{Deserialize, Serialize};
 use std::{path::Path, process::Command};
 use tracing::{debug, trace};
@@ -74,7 +75,9 @@ impl PackageProvider for Homebrew {
             .collect())
     }
 
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+    fn install(&self, package: &PackageVariant, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+        // Does not require privilege escalation
+
         let need_installed = self.query(package)?;
 
         if need_installed.is_empty() {

--- a/lib/src/actions/package/providers/homebrew.rs
+++ b/lib/src/actions/package/providers/homebrew.rs
@@ -2,7 +2,7 @@ use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
 use crate::contexts::Contexts;
 use crate::steps::Step;
-use crate::{actions::package::PackageVariant, atoms::command::Exec, utilities};
+use crate::{actions::package::PackageVariant, atoms::command::Exec};
 use serde::{Deserialize, Serialize};
 use std::{path::Path, process::Command};
 use tracing::{debug, trace};
@@ -20,7 +20,7 @@ impl PackageProvider for Homebrew {
         which("brew").is_ok()
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, _contexts: &Contexts) -> Vec<Step> {
         vec![Step { atom: Box::new(Exec {
             command: String::from("bash"),
             arguments: vec![

--- a/lib/src/actions/package/providers/homebrew.rs
+++ b/lib/src/actions/package/providers/homebrew.rs
@@ -38,7 +38,7 @@ impl PackageProvider for Homebrew {
         false
     }
 
-    fn add_repository(&self, repository: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, repository: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![Step {
             atom: Box::new(Exec {
                 command: String::from("brew"),

--- a/lib/src/actions/package/providers/homebrew.rs
+++ b/lib/src/actions/package/providers/homebrew.rs
@@ -38,7 +38,11 @@ impl PackageProvider for Homebrew {
         false
     }
 
-    fn add_repository(&self, repository: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        repository: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![Step {
             atom: Box::new(Exec {
                 command: String::from("brew"),

--- a/lib/src/actions/package/providers/macports.rs
+++ b/lib/src/actions/package/providers/macports.rs
@@ -25,7 +25,7 @@ impl PackageProvider for Macports {
         }
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, _contexts: &Contexts) -> Vec<Step> {
         vec![]
     }
 

--- a/lib/src/actions/package/providers/macports.rs
+++ b/lib/src/actions/package/providers/macports.rs
@@ -36,7 +36,11 @@ impl PackageProvider for Macports {
         false
     }
 
-    fn add_repository(&self, _repository: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        _repository: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/macports.rs
+++ b/lib/src/actions/package/providers/macports.rs
@@ -36,7 +36,7 @@ impl PackageProvider for Macports {
         false
     }
 
-    fn add_repository(&self, _repository: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, _repository: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/macports.rs
+++ b/lib/src/actions/package/providers/macports.rs
@@ -1,7 +1,8 @@
 use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
+use crate::contexts::Contexts;
 use crate::steps::Step;
-use crate::{actions::package::PackageVariant, atoms::command::Exec};
+use crate::{actions::package::PackageVariant, atoms::command::Exec, utilities};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use which::which;
@@ -43,7 +44,7 @@ impl PackageProvider for Macports {
         Ok(vec![])
     }
 
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+    fn install(&self, package: &PackageVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         let cli = match which("port") {
             Ok(c) => c,
             Err(_) => {
@@ -51,6 +52,9 @@ impl PackageProvider for Macports {
                 return Ok(vec![]);
             }
         };
+
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
 
         Ok(vec![Step {
             atom: Box::new(Exec {
@@ -61,6 +65,7 @@ impl PackageProvider for Macports {
                     .chain(package.packages())
                     .collect(),
                 privileged: true,
+                privilege_provider: privilege_provider.clone(),
                 ..Default::default()
             }),
             initializers: vec![],

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -116,7 +116,7 @@ pub trait PackageProvider {
     fn available(&self) -> bool;
     fn bootstrap(&self) -> Vec<Step>;
     fn has_repository(&self, package: &PackageRepository) -> bool;
-    fn add_repository(&self, package: &PackageRepository) -> anyhow::Result<Vec<Step>>;
+    fn add_repository(&self, package: &PackageRepository, contexts: &Contexts) -> anyhow::Result<Vec<Step>>;
     fn query(&self, package: &PackageVariant) -> anyhow::Result<Vec<String>>;
     fn install(&self, package: &PackageVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>>;
 }

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -116,7 +116,11 @@ pub trait PackageProvider {
     fn available(&self) -> bool;
     fn bootstrap(&self) -> Vec<Step>;
     fn has_repository(&self, package: &PackageRepository) -> bool;
-    fn add_repository(&self, package: &PackageRepository, contexts: &Contexts) -> anyhow::Result<Vec<Step>>;
+    fn add_repository(
+        &self,
+        package: &PackageRepository,
+        contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>>;
     fn query(&self, package: &PackageVariant) -> anyhow::Result<Vec<String>>;
     fn install(&self, package: &PackageVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>>;
 }

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -114,7 +114,7 @@ impl Default for PackageProviders {
 pub trait PackageProvider {
     fn name(&self) -> &str;
     fn available(&self) -> bool;
-    fn bootstrap(&self) -> Vec<Step>;
+    fn bootstrap(&self, contexts: &Contexts) -> Vec<Step>;
     fn has_repository(&self, package: &PackageRepository) -> bool;
     fn add_repository(
         &self,

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -20,6 +20,7 @@ use self::xbps::Xbps;
 mod zypper;
 use self::zypper::Zypper;
 use super::{repository::PackageRepository, PackageVariant};
+use crate::contexts::Contexts;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -117,5 +118,5 @@ pub trait PackageProvider {
     fn has_repository(&self, package: &PackageRepository) -> bool;
     fn add_repository(&self, package: &PackageRepository) -> anyhow::Result<Vec<Step>>;
     fn query(&self, package: &PackageVariant) -> anyhow::Result<Vec<String>>;
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>>;
+    fn install(&self, package: &PackageVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>>;
 }

--- a/lib/src/actions/package/providers/pkgin.rs
+++ b/lib/src/actions/package/providers/pkgin.rs
@@ -1,13 +1,13 @@
 use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
+use crate::contexts::Contexts;
 use crate::steps::finalizers::FlowControl::StopIf;
 use crate::steps::finalizers::OutputContains;
 use crate::steps::Step;
-use crate::{actions::package::PackageVariant, atoms::command::Exec};
+use crate::{actions::package::PackageVariant, atoms::command::Exec, utilities};
 use serde::{Deserialize, Serialize};
 use tracing::{instrument, warn};
 use which::which;
-// use os_info;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Pkgin {}
@@ -48,7 +48,10 @@ impl PackageProvider for Pkgin {
         Ok(package.packages())
     }
 
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+    fn install(&self, package: &PackageVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
+
         Ok(vec![
             Step {
                 atom: Box::new(Exec {
@@ -59,6 +62,7 @@ impl PackageProvider for Pkgin {
                         .chain(package.packages())
                         .collect(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],
@@ -73,6 +77,7 @@ impl PackageProvider for Pkgin {
                         .chain(package.packages())
                         .collect(),
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],

--- a/lib/src/actions/package/providers/pkgin.rs
+++ b/lib/src/actions/package/providers/pkgin.rs
@@ -37,7 +37,11 @@ impl PackageProvider for Pkgin {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        _: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/pkgin.rs
+++ b/lib/src/actions/package/providers/pkgin.rs
@@ -37,7 +37,7 @@ impl PackageProvider for Pkgin {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/pkgin.rs
+++ b/lib/src/actions/package/providers/pkgin.rs
@@ -28,7 +28,7 @@ impl PackageProvider for Pkgin {
     }
 
     #[instrument(name = "bootstrap", level = "info", skip(self))]
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, _contexts: &Contexts) -> Vec<Step> {
         // TODO: Adjust for boot strapping pkgin
         vec![]
     }

--- a/lib/src/actions/package/providers/winget.rs
+++ b/lib/src/actions/package/providers/winget.rs
@@ -1,5 +1,6 @@
 use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
+use crate::contexts::Contexts;
 use crate::steps::Step;
 use crate::{actions::package::PackageVariant, atoms::command::Exec};
 use serde::{Deserialize, Serialize};
@@ -41,7 +42,9 @@ impl PackageProvider for Winget {
         Ok(package.packages())
     }
 
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+    fn install(&self, package: &PackageVariant, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+        // does not require privilege escalation
+
         Ok(package
             .packages()
             .iter()

--- a/lib/src/actions/package/providers/winget.rs
+++ b/lib/src/actions/package/providers/winget.rs
@@ -25,7 +25,7 @@ impl PackageProvider for Winget {
         }
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, _contexts: &Contexts) -> Vec<Step> {
         vec![]
     }
 

--- a/lib/src/actions/package/providers/winget.rs
+++ b/lib/src/actions/package/providers/winget.rs
@@ -33,7 +33,7 @@ impl PackageProvider for Winget {
         true
     }
 
-    fn add_repository(&self, _: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/winget.rs
+++ b/lib/src/actions/package/providers/winget.rs
@@ -33,7 +33,11 @@ impl PackageProvider for Winget {
         true
     }
 
-    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        _: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/xbps.rs
+++ b/lib/src/actions/package/providers/xbps.rs
@@ -2,7 +2,9 @@ use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
 use crate::actions::package::PackageVariant;
 use crate::atoms::command::Exec;
+use crate::contexts::Contexts;
 use crate::steps::Step;
+use crate::utilities;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::process::Command;
@@ -86,11 +88,14 @@ impl PackageProvider for Xbps {
             .collect())
     }
 
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+    fn install(&self, package: &PackageVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         let need_installed = self.query(package)?;
         if need_installed.is_empty() {
             return Ok(vec![]);
         }
+
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
 
         Ok(vec![Step {
             atom: Box::new(Exec {
@@ -106,6 +111,7 @@ impl PackageProvider for Xbps {
                 ]
                 .concat(),
                 privileged: true,
+                privilege_provider: privilege_provider.clone(),
                 ..Default::default()
             }),
             initializers: vec![],

--- a/lib/src/actions/package/providers/xbps.rs
+++ b/lib/src/actions/package/providers/xbps.rs
@@ -49,7 +49,11 @@ impl PackageProvider for Xbps {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        _: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/xbps.rs
+++ b/lib/src/actions/package/providers/xbps.rs
@@ -41,7 +41,7 @@ impl PackageProvider for Xbps {
         install && query
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, _contexts: &Contexts) -> Vec<Step> {
         vec![]
     }
 

--- a/lib/src/actions/package/providers/xbps.rs
+++ b/lib/src/actions/package/providers/xbps.rs
@@ -49,7 +49,7 @@ impl PackageProvider for Xbps {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -77,7 +77,11 @@ impl PackageProvider for Yay {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        _: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -2,7 +2,7 @@ use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
 use crate::actions::package::PackageVariant;
 use crate::atoms::command::Exec;
-use crate::contexts::Contexts;
+use crate::contexts::{Context, Contexts};
 use crate::steps::Step;
 use crate::utilities;
 use serde::{Deserialize, Serialize};
@@ -77,7 +77,7 @@ impl PackageProvider for Yay {
         false
     }
 
-    fn add_repository(&self, _: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, _: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -2,7 +2,7 @@ use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
 use crate::actions::package::PackageVariant;
 use crate::atoms::command::Exec;
-use crate::contexts::{Context, Contexts};
+use crate::contexts::Contexts;
 use crate::steps::Step;
 use crate::utilities;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,10 @@ impl PackageProvider for Yay {
         }
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, contexts: &Contexts) -> Vec<Step> {
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| "sudo".to_string());
+
         vec![
             Step {
                 atom: Box::new(Exec {
@@ -42,6 +45,7 @@ impl PackageProvider for Yay {
                         String::from("git"),
                     ],
                     privileged: true,
+                    privilege_provider: privilege_provider.clone(),
                     ..Default::default()
                 }),
                 initializers: vec![],

--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -2,7 +2,9 @@ use super::PackageProvider;
 use crate::actions::package::repository::PackageRepository;
 use crate::actions::package::PackageVariant;
 use crate::atoms::command::Exec;
+use crate::contexts::Contexts;
 use crate::steps::Step;
+use crate::utilities;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::process::Command;
@@ -114,7 +116,9 @@ impl PackageProvider for Yay {
             .collect())
     }
 
-    fn install(&self, package: &PackageVariant) -> anyhow::Result<Vec<Step>> {
+    fn install(&self, package: &PackageVariant, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+        // Does not require privilege escalation?
+
         let need_installed = self.query(package)?;
         if need_installed.is_empty() {
             return Ok(vec![]);

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -34,7 +34,11 @@ impl PackageProvider for Zypper {
         false
     }
 
-    fn add_repository(&self, _repository: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(
+        &self,
+        _repository: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -34,7 +34,7 @@ impl PackageProvider for Zypper {
         false
     }
 
-    fn add_repository(&self, _repository: &PackageRepository) -> anyhow::Result<Vec<Step>> {
+    fn add_repository(&self, _repository: &PackageRepository, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         Ok(vec![])
     }
 

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -67,19 +67,24 @@ impl PackageProvider for Zypper {
 #[cfg(test)]
 mod test {
     use crate::actions::package::providers::PackageProviders;
+    use crate::contexts::Contexts;
 
     use super::*;
 
     #[test]
     fn test_install() {
         let zypper = Zypper {};
-        let steps = zypper.install(&PackageVariant {
-            name: Some(String::from("")),
-            list: vec![],
-            extra_args: vec![],
-            provider: PackageProviders::Zypper,
-            file: false,
-        });
+        let contexts = Contexts::default();
+        let steps = zypper.install(
+            &PackageVariant {
+                name: Some(String::from("")),
+                list: vec![],
+                extra_args: vec![],
+                provider: PackageProviders::Zypper,
+                file: false,
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 1);
     }

--- a/lib/src/actions/package/providers/zypper.rs
+++ b/lib/src/actions/package/providers/zypper.rs
@@ -26,7 +26,7 @@ impl PackageProvider for Zypper {
         }
     }
 
-    fn bootstrap(&self) -> Vec<Step> {
+    fn bootstrap(&self, _contexts: &Contexts) -> Vec<Step> {
         vec![]
     }
 

--- a/lib/src/actions/package/repository.rs
+++ b/lib/src/actions/package/repository.rs
@@ -48,14 +48,14 @@ impl Action for PackageRepository {
 
         // If the provider isn't available, see if we can bootstrap it
         if !provider.available() {
-            if provider.bootstrap().is_empty() {
+            if provider.bootstrap(&context).is_empty() {
                 return Err(anyhow!(
                     "Package Provider, {}, isn't available. Skipping action",
                     provider.name()
                 ));
             }
 
-            atoms.append(&mut provider.bootstrap());
+            atoms.append(&mut provider.bootstrap(&context));
         }
 
         if !provider.has_repository(self) {

--- a/lib/src/actions/package/repository.rs
+++ b/lib/src/actions/package/repository.rs
@@ -33,7 +33,7 @@ impl Action for PackageRepository {
         format!("Adding repository {}", self.name)
     }
 
-    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn plan(&self, _manifest: &Manifest, context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let box_provider = self.provider.clone().get_provider();
         let provider = box_provider.deref();
 
@@ -59,7 +59,7 @@ impl Action for PackageRepository {
         }
 
         if !provider.has_repository(self) {
-            atoms.append(&mut provider.add_repository(self)?);
+            atoms.append(&mut provider.add_repository(self, &context)?);
         }
 
         span.exit();

--- a/lib/src/actions/user/add.rs
+++ b/lib/src/actions/user/add.rs
@@ -30,7 +30,7 @@ impl Action for UserAdd {
         }
 
         #[cfg(not(unix))]
-        atoms.append(&mut provider.add_user(&variant)?);
+        atoms.append(&mut provider.add_user(&variant, &context)?);
 
         Ok(atoms)
     }

--- a/lib/src/actions/user/add.rs
+++ b/lib/src/actions/user/add.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 pub type UserAdd = User;
 
 impl Action for UserAdd {
-    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn plan(&self, _manifest: &Manifest, context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: UserVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();
         let provider = box_provider.deref();
@@ -26,7 +26,7 @@ impl Action for UserAdd {
         #[cfg(unix)]
         match uzers::get_user_by_name(&variant.username) {
             Some(_user) => debug!(message = "User already exists", username = ?variant.username),
-            None => atoms.append(&mut provider.add_user(&variant)?),
+            None => atoms.append(&mut provider.add_user(&variant, &context)?),
         }
 
         #[cfg(not(unix))]

--- a/lib/src/actions/user/add_group.rs
+++ b/lib/src/actions/user/add_group.rs
@@ -21,13 +21,13 @@ pub struct UserAddGroup {
 }
 
 impl Action for UserAddGroup {
-    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+    fn plan(&self, _manifest: &Manifest, context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let box_provider = self.provider.clone().get_provider();
         let provider = box_provider.deref();
 
         let mut atoms: Vec<Step> = vec![];
 
-        atoms.append(&mut provider.add_to_group(self)?);
+        atoms.append(&mut provider.add_to_group(self, &context)?);
 
         Ok(atoms)
     }

--- a/lib/src/actions/user/providers/freebsd.rs
+++ b/lib/src/actions/user/providers/freebsd.rs
@@ -114,23 +114,27 @@ impl UserProvider for FreeBSDUserProvider {
     }
 }
 
-#[cfg(target_os = "freebsd")]
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{FreeBSDUserProvider, UserProvider};
     use crate::actions::user::{add_group::UserAddGroup, UserVariant};
+    use crate::contexts::Contexts;
 
     #[test]
     fn test_add_user() {
         let user_provider = FreeBSDUserProvider {};
-        let steps = user_provider.add_user(&UserVariant {
-            username: String::from("test"),
-            shell: String::from("sh"),
-            home_dir: String::from("/home/test"),
-            fullname: String::from("Test User"),
-            group: vec![],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_user(
+            &UserVariant {
+                username: String::from("test"),
+                shell: String::from("sh"),
+                home_dir: String::from("/home/test"),
+                fullname: String::from("Test User"),
+                group: vec![],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 1);
     }

--- a/lib/src/actions/user/providers/freebsd.rs
+++ b/lib/src/actions/user/providers/freebsd.rs
@@ -114,6 +114,7 @@ impl UserProvider for FreeBSDUserProvider {
     }
 }
 
+#[cfg(target_os = "freebsd")]
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{FreeBSDUserProvider, UserProvider};

--- a/lib/src/actions/user/providers/freebsd.rs
+++ b/lib/src/actions/user/providers/freebsd.rs
@@ -142,14 +142,18 @@ mod test {
     #[test]
     fn test_add_user_no_username() {
         let user_provider = FreeBSDUserProvider {};
-        let steps = user_provider.add_user(&UserVariant {
-            username: String::from(""),
-            shell: String::from("sh"),
-            home_dir: String::from("/home/test"),
-            fullname: String::from("Test User"),
-            group: vec![],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_user(
+            &UserVariant {
+                username: String::from(""),
+                shell: String::from("sh"),
+                home_dir: String::from("/home/test"),
+                fullname: String::from("Test User"),
+                group: vec![],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 0);
     }
@@ -157,11 +161,15 @@ mod test {
     #[test]
     fn test_add_to_group() {
         let user_provider = FreeBSDUserProvider {};
-        let steps = user_provider.add_to_group(&UserAddGroup {
-            username: String::from("test"),
-            group: vec![String::from("testgroup"), String::from("wheel")],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_to_group(
+            &UserAddGroup {
+                username: String::from("test"),
+                group: vec![String::from("testgroup"), String::from("wheel")],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 2);
     }
@@ -169,14 +177,18 @@ mod test {
     #[test]
     fn test_create_user_add_to_group() {
         let user_provider = FreeBSDUserProvider {};
-        let steps = user_provider.add_user(&UserVariant {
-            username: String::from("test"),
-            shell: String::from(""),
-            home_dir: String::from(""),
-            fullname: String::from(""),
-            group: vec![String::from("testgroup")],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_user(
+            &UserVariant {
+                username: String::from("test"),
+                shell: String::from(""),
+                home_dir: String::from(""),
+                fullname: String::from(""),
+                group: vec![String::from("testgroup")],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 2);
     }

--- a/lib/src/actions/user/providers/linux.rs
+++ b/lib/src/actions/user/providers/linux.rs
@@ -123,23 +123,27 @@ impl UserProvider for LinuxUserProvider {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{LinuxUserProvider, UserProvider};
     use crate::actions::user::{add_group::UserAddGroup, UserVariant};
+    use crate::contexts::Contexts;
 
     #[test]
     fn test_add_user() {
         let user_provider = LinuxUserProvider {};
-        let steps = user_provider.add_user(&UserVariant {
-            username: String::from("test"),
-            shell: String::from("sh"),
-            home_dir: String::from("/home/test"),
-            fullname: String::from("Test User"),
-            group: vec![],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_user(
+            &UserVariant {
+                username: String::from("test"),
+                shell: String::from("sh"),
+                home_dir: String::from("/home/test"),
+                fullname: String::from("Test User"),
+                group: vec![],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 1);
     }
@@ -147,14 +151,18 @@ mod test {
     #[test]
     fn test_add_user_no_username() {
         let user_provider = LinuxUserProvider {};
-        let steps = user_provider.add_user(&UserVariant {
-            username: String::from(""),
-            shell: String::from("sh"),
-            home_dir: String::from("/home/test"),
-            fullname: String::from("Test User"),
-            group: vec![],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_user(
+            &UserVariant {
+                username: String::from(""),
+                shell: String::from("sh"),
+                home_dir: String::from("/home/test"),
+                fullname: String::from("Test User"),
+                group: vec![],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 0);
     }
@@ -162,11 +170,15 @@ mod test {
     #[test]
     fn test_add_to_group() {
         let user_provider = LinuxUserProvider {};
-        let steps = user_provider.add_to_group(&UserAddGroup {
-            username: String::from("test"),
-            group: vec![String::from("testgroup"), String::from("wheel")],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_to_group(
+            &UserAddGroup {
+                username: String::from("test"),
+                group: vec![String::from("testgroup"), String::from("wheel")],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 2);
     }
@@ -174,14 +186,18 @@ mod test {
     #[test]
     fn test_create_user_add_to_group() {
         let user_provider = LinuxUserProvider {};
-        let steps = user_provider.add_user(&UserVariant {
-            username: String::from("test"),
-            shell: String::from(""),
-            home_dir: String::from(""),
-            fullname: String::from(""),
-            group: vec![String::from("testgroup")],
-            ..Default::default()
-        });
+        let contexts = Contexts::default();
+        let steps = user_provider.add_user(
+            &UserVariant {
+                username: String::from("test"),
+                shell: String::from(""),
+                home_dir: String::from(""),
+                fullname: String::from(""),
+                group: vec![String::from("testgroup")],
+                ..Default::default()
+            },
+            &contexts,
+        );
 
         assert_eq!(steps.unwrap().len(), 2);
     }

--- a/lib/src/actions/user/providers/linux.rs
+++ b/lib/src/actions/user/providers/linux.rs
@@ -123,6 +123,7 @@ impl UserProvider for LinuxUserProvider {
     }
 }
 
+#[cfg(target_os = "linux")]
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{LinuxUserProvider, UserProvider};

--- a/lib/src/actions/user/providers/macos.rs
+++ b/lib/src/actions/user/providers/macos.rs
@@ -127,6 +127,7 @@ impl UserProvider for MacOSUserProvider {
     }
 }
 
+#[cfg(target_os = "macos")]
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{MacOSUserProvider, UserProvider};

--- a/lib/src/actions/user/providers/macos.rs
+++ b/lib/src/actions/user/providers/macos.rs
@@ -127,7 +127,6 @@ impl UserProvider for MacOSUserProvider {
     }
 }
 
-#[cfg(target_os = "macos")]
 #[cfg(test)]
 mod test {
     use crate::actions::user::providers::{MacOSUserProvider, UserProvider};

--- a/lib/src/actions/user/providers/mod.rs
+++ b/lib/src/actions/user/providers/mod.rs
@@ -11,6 +11,8 @@ use self::linux::LinuxUserProvider;
 mod macos;
 use self::macos::MacOSUserProvider;
 
+use crate::contexts::Contexts;
+
 #[derive(JsonSchema, Clone, Debug, Serialize, Deserialize)]
 pub enum UserProviders {
     #[serde(alias = "freebsd")]
@@ -58,6 +60,6 @@ impl Default for UserProviders {
 }
 
 pub trait UserProvider {
-    fn add_user(&self, user: &UserVariant) -> anyhow::Result<Vec<Step>>;
-    fn add_to_group(&self, user: &UserAddGroup) -> anyhow::Result<Vec<Step>>;
+    fn add_user(&self, user: &UserVariant, contexts: &Contexts) -> anyhow::Result<Vec<Step>>;
+    fn add_to_group(&self, user: &UserAddGroup, contexts: &Contexts) -> anyhow::Result<Vec<Step>>;
 }

--- a/lib/src/actions/user/providers/none.rs
+++ b/lib/src/actions/user/providers/none.rs
@@ -1,5 +1,6 @@
 use super::UserProvider;
 use crate::actions::user::{add_group::UserAddGroup, UserVariant};
+use crate::contexts::Contexts;
 use crate::steps::Step;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -8,12 +9,16 @@ use tracing::warn;
 pub struct NoneUserProvider {}
 
 impl UserProvider for NoneUserProvider {
-    fn add_user(&self, _user: &UserVariant) -> anyhow::Result<Vec<Step>> {
+    fn add_user(&self, _user: &UserVariant, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
         warn!("This system does not have a provider for users");
         Ok(vec![])
     }
 
-    fn add_to_group(&self, _user: &UserAddGroup) -> anyhow::Result<Vec<Step>> {
+    fn add_to_group(
+        &self,
+        _user: &UserAddGroup,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
         warn!(message = "This system does not have a provider for users");
         Ok(vec![])
     }

--- a/lib/src/atoms/command/exec.rs
+++ b/lib/src/atoms/command/exec.rs
@@ -1,10 +1,8 @@
 use crate::atoms::Outcome;
 
 use super::super::Atom;
-use crate::contexts::privilege::Privilege;
 use crate::utilities;
 use anyhow::anyhow;
-use serde_yml::libyml::util;
 use tracing::debug;
 
 #[derive(Default)]
@@ -120,7 +118,7 @@ impl Atom for Exec {
 
         // If we require root, we need to use sudo with inherited IO
         // to ensure the user can respond if prompted for a password
-        if command.eq("doas") {
+        if command.eq("doas") || command.eq("sudo") {
             match self.elevate() {
                 Ok(_) => (),
                 Err(err) => {
@@ -178,6 +176,7 @@ impl Atom for Exec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contexts::privilege::Privilege;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -213,6 +212,7 @@ mod tests {
         let mut command_run = new_run_command(String::from("echo"));
         command_run.arguments = vec![String::from("Hello, world!")];
         command_run.privileged = true;
+        command_run.privilege_provider = Privilege::Sudo.to_string();
         let (command, args) = command_run.elevate_if_required();
 
         assert_eq!(String::from("sudo"), command);

--- a/lib/src/atoms/command/exec.rs
+++ b/lib/src/atoms/command/exec.rs
@@ -223,6 +223,28 @@ mod tests {
     }
 
     #[test]
+    fn elevate_doas() {
+        let mut command_run = new_run_command(String::from("echo"));
+        command_run.arguments = vec![String::from("Hello, world!")];
+        let (command, args) = command_run.elevate_if_required();
+
+        assert_eq!(String::from("echo"), command);
+        assert_eq!(vec![String::from("Hello, world!")], args);
+
+        let mut command_run = new_run_command(String::from("echo"));
+        command_run.arguments = vec![String::from("Hello, world!")];
+        command_run.privileged = true;
+        command_run.privilege_provider = Privilege::Doas.to_string();
+        let (command, args) = command_run.elevate_if_required();
+
+        assert_eq!(String::from("doas"), command);
+        assert_eq!(
+            vec![String::from("echo"), String::from("Hello, world!")],
+            args
+        );
+    }
+
+    #[test]
     fn error_propagation() {
         let mut command_run = new_run_command(String::from("non-existant-command"));
         command_run.execute().expect_err("Command should fail");

--- a/lib/src/atoms/command/exec.rs
+++ b/lib/src/atoms/command/exec.rs
@@ -1,8 +1,10 @@
 use crate::atoms::Outcome;
 
 use super::super::Atom;
+use crate::contexts::privilege::Privilege;
 use crate::utilities;
 use anyhow::anyhow;
+use serde_yml::libyml::util;
 use tracing::debug;
 
 #[derive(Default)]
@@ -12,6 +14,7 @@ pub struct Exec {
     pub working_dir: Option<String>,
     pub environment: Vec<(String, String)>,
     pub privileged: bool,
+    pub privilege_provider: String,
     pub(crate) status: ExecStatus,
 }
 
@@ -34,6 +37,9 @@ impl Exec {
     fn elevate_if_required(&self) -> (String, Vec<String>) {
         // Depending on the priviledged flag and who who the current user is
         // we can determine if we need to prepend sudo to the command
+
+        let privilege_provider = self.privilege_provider.clone();
+
         match (self.privileged, whoami::username().as_str()) {
             // Hasn't requested priviledged, so never try to elevate
             (false, _) => (self.command.clone(), self.arguments.clone()),
@@ -43,7 +49,7 @@ impl Exec {
 
             // Requested priviledged, but is not root
             (true, _) => (
-                String::from("sudo"),
+                privilege_provider,
                 [vec![self.command.clone()], self.arguments.clone()].concat(),
             ),
         }
@@ -51,12 +57,14 @@ impl Exec {
 
     fn elevate(&mut self) -> anyhow::Result<()> {
         tracing::info!(
-            "Sudo required for privilege elevation to run `{} {}`. Validating sudo ...",
+            "Privilege elevation required to run `{} {}`. Validating privileges ...",
             &self.command,
             &self.arguments.join(" ")
         );
 
-        match std::process::Command::new("sudo")
+        let privilege_provider = utilities::get_binary_path(&self.privilege_provider)?;
+
+        match std::process::Command::new(privilege_provider)
             .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
@@ -66,12 +74,12 @@ impl Exec {
             Ok(std::process::Output { status, .. }) if status.success() => Ok(()),
 
             Ok(std::process::Output { stderr, .. }) => Err(anyhow!(
-                "Command requires sudo, but couldn't elevate privileges: {}",
+                "Command requires privilege escalation, but couldn't elevate privileges: {}",
                 String::from_utf8(stderr)?
             )),
 
             Err(err) => Err(anyhow!(
-                "Command requires sudo, but couldn't elevate privileges: {}",
+                "Command requires privilege escalation, but couldn't elevate privileges: {}",
                 err
             )),
         }
@@ -112,7 +120,7 @@ impl Atom for Exec {
 
         // If we require root, we need to use sudo with inherited IO
         // to ensure the user can respond if prompted for a password
-        if command.eq("sudo") {
+        if command.eq("doas") {
             match self.elevate() {
                 Ok(_) => (),
                 Err(err) => {

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -1,3 +1,4 @@
+use crate::contexts::privilege::Privilege;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::PathBuf, vec};
@@ -16,6 +17,9 @@ pub struct Config {
 
     #[serde(default)]
     pub disable_update_check: bool,
+
+    #[serde(default)]
+    pub privilege: Privilege,
 }
 
 /// Check the current working directory for a `Comtrya.yaml` file

--- a/lib/src/contexts/mod.rs
+++ b/lib/src/contexts/mod.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use tracing::{instrument, trace, warn};
 use user::UserContextProvider;
 
+use crate::contexts::privilege::PrivilegeContextProvider;
 use crate::{
     config::Config,
     contexts::{
@@ -16,6 +17,7 @@ use crate::{
 
 pub mod env;
 pub mod os;
+pub mod privilege;
 /// User context provider: understands the user running the command
 pub mod user;
 pub mod variable_include;
@@ -44,6 +46,7 @@ pub fn build_contexts(config: &Config) -> Contexts {
         Box::new(EnvContextProvider {}),
         Box::new(VariablesContextProvider { config }),
         Box::new(VariableIncludeContextProvider { config }),
+        Box::new(PrivilegeContextProvider { config }),
     ];
 
     context_providers.iter().for_each(|provider| {

--- a/lib/src/contexts/privilege.rs
+++ b/lib/src/contexts/privilege.rs
@@ -1,0 +1,49 @@
+use crate::config::Config;
+use crate::contexts::{Context, ContextProvider};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Privilege {
+    #[serde(alias = "sudo")]
+    Sudo,
+
+    #[serde(alias = "doas")]
+    Doas,
+}
+
+impl Default for Privilege {
+    fn default() -> Self {
+        Privilege::Sudo
+    }
+}
+
+impl Display for Privilege {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Privilege::Sudo => "sudo".to_string(),
+            Privilege::Doas => "doas".to_string(),
+        };
+        write!(f, "{}", str)
+    }
+}
+
+pub struct PrivilegeContextProvider<'a> {
+    pub config: &'a Config,
+}
+
+impl<'a> ContextProvider for PrivilegeContextProvider<'a> {
+    fn get_prefix(&self) -> String {
+        "privilege".to_string()
+    }
+
+    fn get_contexts(&self) -> anyhow::Result<Vec<Context>> {
+        let mut contexts = vec![];
+
+        contexts.push(Context::KeyValueContext(
+            "privilege".to_string(),
+            self.config.privilege.to_string().into(),
+        ));
+
+        Ok(contexts)
+    }
+}

--- a/lib/src/utilities/mod.rs
+++ b/lib/src/utilities/mod.rs
@@ -1,3 +1,4 @@
+use crate::contexts::Contexts;
 use which;
 
 pub fn get_binary_path(binary: &str) -> Result<String, anyhow::Error> {
@@ -6,4 +7,21 @@ pub fn get_binary_path(binary: &str) -> Result<String, anyhow::Error> {
         .to_string();
 
     Ok(binary)
+}
+
+pub fn get_privilege_provider(contexts: &Contexts) -> Option<String> {
+    // safe because this is guaranteed to be present in contexts
+    // let privilege_provider = contexts
+    //     .get("privilege")
+    //     .unwrap()
+    //     .first_key_value()
+    //     .unwrap()
+    //     .1.to_string();
+    let privilege_provider = contexts.get("privilege").and_then(|s| s.first_key_value());
+
+    if let Some(privilege_provider) = privilege_provider {
+        return Some(privilege_provider.1.to_string());
+    }
+
+    None
 }

--- a/lib/src/utilities/mod.rs
+++ b/lib/src/utilities/mod.rs
@@ -10,13 +10,6 @@ pub fn get_binary_path(binary: &str) -> Result<String, anyhow::Error> {
 }
 
 pub fn get_privilege_provider(contexts: &Contexts) -> Option<String> {
-    // safe because this is guaranteed to be present in contexts
-    // let privilege_provider = contexts
-    //     .get("privilege")
-    //     .unwrap()
-    //     .first_key_value()
-    //     .unwrap()
-    //     .1.to_string();
     let privilege_provider = contexts.get("privilege").and_then(|s| s.first_key_value());
 
     if let Some(privilege_provider) = privilege_provider {


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

Comtrya also utilizes `sudo` for privilege escalation.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Add the ability to specify a provider for privilege escalation with the initial offering of using `doas` as a privilege provider.

## What is the motivation / use case for changing the behavior?

Issue #429 

## Please tell us about your environment:

Version (`comtrya --version`): 0.8.9
Operating system: macOS 15.0
