### PR TITLE
Add run0 as a privilege provider

### DIFF
--- a/lib/src/atoms/command/exec.rs
+++ b/lib/src/atoms/command/exec.rs
@@ -118,7 +118,7 @@ impl Atom for Exec {
 
         // If we require root, we need to use sudo with inherited IO
         // to ensure the user can respond if prompted for a password
-        if command.eq("doas") || command.eq("sudo") {
+        if command.eq("doas") || command.eq("sudo") || command.eq("run0") {
             match self.elevate() {
                 Ok(_) => (),
                 Err(err) => {
@@ -243,6 +243,28 @@ mod tests {
             args
         );
     }
+    #[test]
+    fn elevate_run0() {
+        let mut command_run = new_run_command(String::from("echo"));
+        command_run.arguments = vec![String::from("Hello, world!")];
+        let (command, args) = command_run.elevate_if_required();
+
+        assert_eq!(String::from("echo"), command);
+        assert_eq!(vec![String::from("Hello, world!")], args);
+
+        let mut command_run = new_run_command(String::from("echo"));
+        command_run.arguments = vec![String::from("Hello, world!")];
+        command_run.privileged = true;
+        command_run.privilege_provider = Privilege::Run0.to_string();
+        let (command, args) = command_run.elevate_if_required();
+
+        assert_eq!(String::from("run0"), command);
+        assert_eq!(
+            vec![String::from("echo"), String::from("Hello, world!")],
+            args
+        );
+    }
+
 
     #[test]
     fn error_propagation() {

--- a/lib/src/atoms/command/exec.rs
+++ b/lib/src/atoms/command/exec.rs
@@ -265,7 +265,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn error_propagation() {
         let mut command_run = new_run_command(String::from("non-existant-command"));

--- a/lib/src/contexts/privilege.rs
+++ b/lib/src/contexts/privilege.rs
@@ -9,6 +9,9 @@ pub enum Privilege {
 
     #[serde(alias = "doas")]
     Doas,
+
+    #[serde(alias = "run0")]
+    Run0,
 }
 
 impl Default for Privilege {
@@ -22,6 +25,7 @@ impl Display for Privilege {
         let str = match self {
             Privilege::Sudo => "sudo".to_string(),
             Privilege::Doas => "doas".to_string(),
+            Privilege::Run0 => "run0".to_string(),
         };
         write!(f, "{}", str)
     }


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?
Comtrya only supports sudo and doas as privilege providers.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?
run0 for systemd should also be supported.

## What is the motivation / use case for changing the behavior?
issue #451 

## Please tell us about your environment:

Version (`comtrya --version`): v0.8.9
Operating system: Arch Linux
