### PR TITLE
Add snapcraft to the list of package managers in the documentation

### DIFF
--- a/docs/src/packages.md
+++ b/docs/src/packages.md
@@ -22,6 +22,7 @@ Not all package managers are supported. This is a list of currently supported pa
 | zypper     | OpenSUSE          |
 | macports   | macOS             |
 | dnf        | Fedora            |
+| snapcraft  | Linux             |
 
 
 ### Important note on homebrew and macOS


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition
