### PR TITLE
fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ curl -fsSL https://get.comtrya.dev | sh
 or specify `VERSION=vx.x.x` to pin to a release version
 
 ```shell
-VERSION=v0.9.0 curl -fsSL https://get.comtrya.dev | sh
+curl -fsSL https://get.comtrya.dev | VERSION=v0.9.0 sh
 ```
 
 If this doesn't work for your OS and architecture, please open an issue and we'll do our best to support it.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -29,7 +29,7 @@ curl -fsSL https://get.comtrya.dev | sh
 Or, optionally, you can get a specific version of comtrya using the following one-liner:
 
 ```
-VERSION=v0.9.0 curl -fsSL https://get.comtrya.dev | sh
+curl -fsSL https://get.comtrya.dev | VERSION=v0.9.0  sh
 ```
 
 ## Precompile-binaries


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

## What is the current behaviour?

The documentation has an person passing in VERSION as an environment variable for pinning a specific version of comtrya correctly.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

#494 

## What is the expected behavior?

A person can use the curl and piped to bash script to get a specific version of comtrya.

## What is the motivation / use case for changing the behavior?

#494 

