### PR TITLE
feat: add paru as new providor

### DIFF
--- a/docs/src/packages.md
+++ b/docs/src/packages.md
@@ -13,6 +13,7 @@ Not all package managers are supported. This is a list of currently supported pa
 | Provider   | OS                |
 |:-----------|:------------------|
 | pacman/yay | Arch              |
+| paru       | Arch              |
 | apt        | Debian/Ubuntu     |
 | pkg        | FreeBSD           |
 | pkgin      | NetBSD (Multiple) |
@@ -48,7 +49,7 @@ Some package manager providers can implement a `bootstrap` method that will auto
 # Install package using default provider
 - action: package.install
   name: curl
-  
+
 # Install a list of packages using default provider
 - action: package.install
   list:
@@ -59,7 +60,7 @@ Some package manager providers can implement a `bootstrap` method that will auto
 - action: package install
   name: curl
   provider: pkgin
-  
+
 # Install a package specifying a repository
 - action: package.install
   name: blox

--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -9,6 +9,8 @@ mod homebrew;
 use self::homebrew::Homebrew;
 mod macports;
 use self::macports::Macports;
+mod paru;
+use self::paru::Paru;
 mod pkgin;
 use self::pkgin::Pkgin;
 mod snapcraft;
@@ -52,6 +54,9 @@ pub enum PackageProviders {
     #[serde(rename = "yay", alias = "pacman")]
     Yay,
 
+    #[serde(rename = "paru")]
+    Paru,
+
     #[serde(rename = "winget")]
     Winget,
 
@@ -72,6 +77,7 @@ impl PackageProviders {
             PackageProviders::Macports => Box::new(Macports {}),
             PackageProviders::Pkgin => Box::new(Pkgin {}),
             PackageProviders::Yay => Box::new(Yay {}),
+            PackageProviders::Paru => Box::new(Paru {}),
             PackageProviders::Winget => Box::new(Winget {}),
             PackageProviders::Xbps => Box::new(Xbps {}),
             PackageProviders::Zypper => Box::new(Zypper {}),

--- a/lib/src/actions/package/providers/paru.rs
+++ b/lib/src/actions/package/providers/paru.rs
@@ -1,0 +1,153 @@
+use super::PackageProvider;
+use crate::actions::package::repository::PackageRepository;
+use crate::actions::package::PackageVariant;
+use crate::atoms::command::Exec;
+use crate::contexts::Contexts;
+use crate::steps::Step;
+use crate::utilities;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::process::Command;
+use tracing::warn;
+use tracing::{debug, trace};
+use which::which;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Paru {}
+
+impl PackageProvider for Paru {
+    fn name(&self) -> &str {
+        "Paru"
+    }
+
+    fn available(&self) -> bool {
+        match which("paru") {
+            Ok(_) => true,
+            Err(_) => {
+                warn!(message = "paru not available");
+                false
+            }
+        }
+    }
+
+    fn bootstrap(&self, contexts: &Contexts) -> Vec<Step> {
+        let privilege_provider =
+            utilities::get_privilege_provider(&contexts).unwrap_or_else(|| String::from("sudo"));
+
+        vec![
+            Step {
+                atom: Box::new(Exec {
+                    command: String::from("pacman"),
+                    arguments: vec![
+                        String::from("-S"),
+                        String::from("--noconfirm"),
+                        String::from("--needed"),
+                        String::from("base-devel"),
+                        String::from("git"),
+                    ],
+                    privileged: true,
+                    privilege_provider: privilege_provider.clone(),
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            },
+            Step {
+                atom: Box::new(Exec {
+                    command: String::from("git"),
+                    arguments: vec![
+                        String::from("clone"),
+                        String::from("https://aur.archlinux.org/paru.git"),
+                        String::from("/tmp/paru"),
+                    ],
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            },
+            Step {
+                atom: Box::new(Exec {
+                    command: String::from("makepkg"),
+                    arguments: vec![String::from("-si"), String::from("--noconfirm")],
+                    working_dir: Some(String::from("/tmp/paru")),
+                    ..Default::default()
+                }),
+                initializers: vec![],
+                finalizers: vec![],
+            },
+        ]
+    }
+
+    fn has_repository(&self, _: &PackageRepository) -> bool {
+        false
+    }
+
+    fn add_repository(
+        &self,
+        _: &PackageRepository,
+        _contexts: &Contexts,
+    ) -> anyhow::Result<Vec<Step>> {
+        Ok(vec![])
+    }
+
+    fn query(&self, package: &PackageVariant) -> anyhow::Result<Vec<String>> {
+        let requested_already_installed: HashSet<String> = String::from_utf8(
+            Command::new("paru")
+                .args(
+                    vec![String::from("-Qq")]
+                        .into_iter()
+                        .chain(package.packages().into_iter()),
+                )
+                .output()?
+                .stdout,
+        )?
+        .split('\n')
+        .map(String::from)
+        .collect();
+
+        debug!(
+            "all requested installed packages: {:?}",
+            requested_already_installed
+        );
+
+        Ok(package
+            .packages()
+            .into_iter()
+            .filter(|p| {
+                if requested_already_installed.contains(p) {
+                    trace!("{}: already installed", p);
+                    false
+                } else {
+                    debug!("{}: doesn't appear to be installed", p);
+                    true
+                }
+            })
+            .collect())
+    }
+
+    fn install(&self, package: &PackageVariant, _contexts: &Contexts) -> anyhow::Result<Vec<Step>> {
+        Ok(vec![Step {
+            atom: Box::new(Exec {
+                command: String::from("paru"),
+                arguments: [
+                    vec![
+                        String::from("-Sq"),
+                        String::from("--batchinstall"),
+                        String::from("--needed"),
+                        String::from("--noconfirm"),
+                        String::from("--noprogressbar"),
+                        String::from("--skipreview"),
+                        String::from("--sudoloop"),
+                        String::from("--useask"),
+                    ],
+                    package.extra_args.clone(),
+                    package.packages(),
+                ]
+                .concat(),
+                ..Default::default()
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }])
+    }
+}


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [x] documentation addition

## What is the current behaviour?

Comtrya does not have a provider for [Paru](https://github.com/Morganamilo/paru)

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

Not a bug

## What is the expected behavior?

Addition of Paru to the list of available providers

## What is the motivation / use case for changing the behavior?

Paru is my preferred AUR helper and I'm sure others would want the option to use Paru over Yay

## Please tell us about your environment:

Version (`comtrya --version`): comtrya 0.9.0
Operating system: Arch
