### PR TITLE
fix(yay): remove deprecated option

### DIFF
--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -139,7 +139,6 @@ impl PackageProvider for Yay {
                     vec![
                         String::from("-S"),
                         String::from("--noconfirm"),
-                        String::from("--nocleanmenu"),
                         String::from("--nodiffmenu"),
                     ],
                     package.extra_args.clone(),


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

yay provider should work

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

flag was removed and is now the default
