### PR TITLE
fix(arch): ensure queries can run when provider needs bootstrapped

### DIFF
--- a/lib/src/actions/package/providers/paru.rs
+++ b/lib/src/actions/package/providers/paru.rs
@@ -92,7 +92,7 @@ impl PackageProvider for Paru {
 
     fn query(&self, package: &PackageVariant) -> anyhow::Result<Vec<String>> {
         let requested_already_installed: HashSet<String> = String::from_utf8(
-            Command::new("paru")
+            Command::new("pacman")
                 .args(
                     vec![String::from("-Qq")]
                         .into_iter()

--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -91,7 +91,7 @@ impl PackageProvider for Yay {
 
     fn query(&self, package: &PackageVariant) -> anyhow::Result<Vec<String>> {
         let requested_already_installed: HashSet<String> = String::from_utf8(
-            Command::new("yay")
+            Command::new("pacman")
                 .args(
                     vec![String::from("-Q"), String::from("-q")]
                         .into_iter()


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Currently, we can't bootstrap these two providers because the query steps fail to run during a plan for package installations.

We can use pacman to satisfy queries to understand if the plans need action, without requiring the bootstrap to run first.