### PR TITLE
fix(arch): no diffmenu is now the default and the flag was removed

### DIFF
--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -139,7 +139,6 @@ impl PackageProvider for Yay {
                     vec![
                         String::from("-S"),
                         String::from("--noconfirm"),
-                        String::from("--nodiffmenu"),
                     ],
                     package.extra_args.clone(),
                     need_installed,

--- a/lib/src/actions/package/providers/yay.rs
+++ b/lib/src/actions/package/providers/yay.rs
@@ -136,10 +136,7 @@ impl PackageProvider for Yay {
             atom: Box::new(Exec {
                 command: String::from("yay"),
                 arguments: [
-                    vec![
-                        String::from("-S"),
-                        String::from("--noconfirm"),
-                    ],
+                    vec![String::from("-S"), String::from("--noconfirm")],
                     package.extra_args.clone(),
                     need_installed,
                 ]


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
