### PR TITLE
feat: chown files on download

### DIFF
--- a/examples/file/file-download-chown.yaml
+++ b/examples/file/file-download-chown.yaml
@@ -1,0 +1,7 @@
+actions:
+  # This will be rendered with contexts
+  - action: file.download
+    from: https://google.com/robots.txt
+    to: /tmp/google-robots.txt
+    owned_by_user: nobody
+    owned_by_group: nobody

--- a/lib/src/actions/file/download.rs
+++ b/lib/src/actions/file/download.rs
@@ -168,6 +168,6 @@ mod tests {
         let steps = file_download.plan(&Default::default(), &Default::default());
         assert!(steps.is_ok());
         let steps = steps.unwrap();
-        assert_eq!(5, steps.len());
+        assert_eq!(4, steps.len());
     }
 }

--- a/lib/src/actions/file/download.rs
+++ b/lib/src/actions/file/download.rs
@@ -130,35 +130,12 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn it_can_be_deserialized_user_owner() {
+    fn it_can_be_deserialized_owners() {
         let yaml = r#"
 - action: file.download
   from: a
   to: b
   owned_by_user: test
-"#;
-
-        let mut actions: Vec<Actions> = serde_yml::from_str(yaml).unwrap();
-
-        match actions.pop() {
-            Some(Actions::FileDownload(action)) => {
-                assert_eq!("a", action.action.from);
-                assert_eq!("b", action.action.to);
-                assert_eq!("test", action.action.owner_user.unwrap());
-            }
-            _ => {
-                panic!("FileDownload didn't deserialize to the correct type");
-            }
-        };
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn it_can_be_deserialized_group_owner() {
-        let yaml = r#"
-- action: file.download
-  from: a
-  to: b
   owned_by_group: test
 "#;
 
@@ -168,6 +145,7 @@ mod tests {
             Some(Actions::FileDownload(action)) => {
                 assert_eq!("a", action.action.from);
                 assert_eq!("b", action.action.to);
+                assert_eq!("test", action.action.owner_user.unwrap());
                 assert_eq!("test", action.action.owner_group.unwrap());
             }
             _ => {
@@ -178,47 +156,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn contains_owner_user() {
-        let file_download = FileDownload {
-            from: "test".to_string(),
-            to: "abc".to_string(),
-            chmod: 1,
-            template: false,
-            owner_user: Some("test".to_string()),
-            owner_group: None,
-        };
-
-        let steps = file_download.plan(&Default::default(), &Default::default());
-
-        assert_eq!(true, steps.is_ok());
-
-        let steps = steps.unwrap();
-        assert_eq!(4, steps.len());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn contains_owner_group() {
-        let file_download = FileDownload {
-            from: "test".to_string(),
-            to: "abc".to_string(),
-            chmod: 1,
-            template: false,
-            owner_user: None,
-            owner_group: Some("test".to_string()),
-        };
-
-        let steps = file_download.plan(&Default::default(), &Default::default());
-
-        assert_eq!(true, steps.is_ok());
-
-        let steps = steps.unwrap();
-        assert_eq!(4, steps.len());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn contains_owner_group_and_owner_user() {
+    fn contains_chown_step() {
         let file_download = FileDownload {
             from: "test".to_string(),
             to: "abc".to_string(),

--- a/lib/src/actions/file/download.rs
+++ b/lib/src/actions/file/download.rs
@@ -166,9 +166,7 @@ mod tests {
         };
 
         let steps = file_download.plan(&Default::default(), &Default::default());
-
-        assert_eq!(true, steps.is_ok());
-
+        assert!(steps.is_ok());
         let steps = steps.unwrap();
         assert_eq!(5, steps.len());
     }

--- a/lib/src/actions/file/download.rs
+++ b/lib/src/actions/file/download.rs
@@ -105,7 +105,6 @@ impl Action for FileDownload {
 mod tests {
     use crate::actions::file::download::FileDownload;
     use crate::actions::{Action, Actions};
-    use crate::atoms::file::Chown;
 
     #[test]
     fn it_can_be_deserialized() {

--- a/lib/src/atoms/file/chown.rs
+++ b/lib/src/atoms/file/chown.rs
@@ -123,7 +123,6 @@ impl Atom for Chown {
     }
 
     fn execute(&mut self) -> anyhow::Result<()> {
-        println!("{:#?}", self);
         if !self.owner.is_empty() {
             self.path.set_owner(self.owner.as_str())?;
         }


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

Comtrya does not currently have the ability to run a chown in conjunction with a `file.download` action.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Optional ability to have a chown run on a `file.download` action if an user owner and user group is specified on unix systems.

## What is the motivation / use case for changing the behavior?

issue #500 

## Please tell us about your environment:

Version (`comtrya --version`): main
Operating system: macOS 15.1
