### PR TITLE
feat: add unarchive file action

### DIFF
--- a/examples/file/file-unarchive.yaml
+++ b/examples/file/file-unarchive.yaml
@@ -1,0 +1,8 @@
+actions:
+  - action: file.download
+    from: https://github.com/comtrya/comtrya/archive/refs/tags/v0.9.0.tar.gz
+    to: /tmp/comtrya
+  
+  - action: file.unarchive
+    from: /tmp/comtrya
+    to: /tmp/

--- a/lib/src/actions/file/mod.rs
+++ b/lib/src/actions/file/mod.rs
@@ -3,6 +3,7 @@ pub mod copy;
 pub mod download;
 pub mod link;
 pub mod remove;
+pub mod unarchive;
 
 use crate::actions::Action;
 use crate::manifests::Manifest;

--- a/lib/src/actions/file/unarchive.rs
+++ b/lib/src/actions/file/unarchive.rs
@@ -1,0 +1,68 @@
+use super::FileAction;
+use crate::atoms::file::Unarchive;
+use crate::manifests::Manifest;
+use crate::steps::Step;
+use crate::{actions::Action, contexts::Contexts};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(JsonSchema, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileUnarchive {
+    #[serde(alias = "source")]
+    pub from: String,
+
+    #[serde(alias = "target")]
+    pub to: String,
+
+    pub force: Option<bool>,
+}
+
+impl FileUnarchive {}
+
+impl FileAction for FileUnarchive {}
+
+impl Action for FileUnarchive {
+    fn summarize(&self) -> String {
+        format!("Unarchiving file {} to {}", self.from, self.to)
+    }
+
+    fn plan(&self, _manifest: &Manifest, _context: &Contexts) -> anyhow::Result<Vec<Step>> {
+        let steps = vec![Step {
+            atom: Box::new(Unarchive {
+                origin: self.from.clone().into(),
+                dest: self.to.clone().into(),
+                force: self.force.unwrap_or(true),
+            }),
+            initializers: vec![],
+            finalizers: vec![],
+        }];
+
+        Ok(steps)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::Actions;
+
+    #[test]
+    fn it_can_be_deserialized() {
+        let yaml = r#"
+- action: file.unarchive
+  from: a
+  to: b
+"#;
+
+        let mut actions: Vec<Actions> = serde_yml::from_str(yaml).unwrap();
+
+        match actions.pop() {
+            Some(Actions::FileUnarchive(action)) => {
+                assert_eq!("a", action.action.from);
+                assert_eq!("b", action.action.to);
+            }
+            _ => {
+                panic!("FileCopy didn't deserialize to the correct type");
+            }
+        };
+    }
+}

--- a/lib/src/actions/mod.rs
+++ b/lib/src/actions/mod.rs
@@ -19,6 +19,7 @@ use file::copy::FileCopy;
 use file::download::FileDownload;
 use file::link::FileLink;
 use file::remove::FileRemove;
+use file::unarchive::FileUnarchive;
 use group::add::GroupAdd;
 use macos::MacOSDefault;
 use package::{PackageInstall, PackageRepository};
@@ -127,6 +128,9 @@ pub enum Actions {
     #[serde(rename = "file.remove")]
     FileRemove(ConditionalVariantAction<FileRemove>),
 
+    #[serde(rename = "file.unarchive")]
+    FileUnarchive(ConditionalVariantAction<FileUnarchive>),
+
     #[serde(rename = "directory.remove", alias = "dir.remove")]
     DirectoryRemove(ConditionalVariantAction<DirectoryRemove>),
 
@@ -168,6 +172,7 @@ impl Actions {
             Actions::FileChown(a) => a,
             Actions::FileDownload(a) => a,
             Actions::FileLink(a) => a,
+            Actions::FileUnarchive(a) => a,
             Actions::GroupAdd(a) => a,
             Actions::MacOSDefault(a) => a,
             Actions::PackageInstall(a) => a,
@@ -191,6 +196,7 @@ impl Display for Actions {
             Actions::FileDownload(_) => "file.download",
             Actions::FileLink(_) => "file.link",
             Actions::FileRemove(_) => "file.remove",
+            Actions::FileUnarchive(_) => "file.unarchive",
             Actions::DirectoryRemove(_) => "directory.remove",
             Actions::BinaryGitHub(_) => "github.binary",
             Actions::GroupAdd(_) => "group.add",


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [x] feature
- [ ] documentation addition

## What is the current behaviour?

Comtrya is not able to unarchive files

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Provide an action that can unarchive .tar.gz files

## What is the motivation / use case for changing the behavior?

#231 



## Please tell us about your environment:

Version (`comtrya --version`): v0.9.0
Operating system: macOS 15.1.1
