### PR TITLE
add summary for action

### DIFF
--- a/lib/src/actions/binary/github.rs
+++ b/lib/src/actions/binary/github.rs
@@ -25,6 +25,10 @@ struct GitHubAsset {
 }
 
 impl Action for BinaryGitHub {
+    fn summarize(&self) -> String {
+        format!("Downloading binary from {} to {}", self.repository, self.directory)
+    }
+    
     fn plan(&self, _: &Manifest, _: &Contexts) -> anyhow::Result<Vec<Step>> {
         // Don't need to do anything if something already exists at the path
         if std::path::Path::new(format!("{}/{}", self.directory, self.name).as_str()).exists() {

--- a/lib/src/actions/binary/github.rs
+++ b/lib/src/actions/binary/github.rs
@@ -26,9 +26,12 @@ struct GitHubAsset {
 
 impl Action for BinaryGitHub {
     fn summarize(&self) -> String {
-        format!("Downloading binary from {} to {}", self.repository, self.directory)
+        format!(
+            "Downloading binary from {} to {}",
+            self.repository, self.directory
+        )
     }
-    
+
     fn plan(&self, _: &Manifest, _: &Contexts) -> anyhow::Result<Vec<Step>> {
         // Don't need to do anything if something already exists at the path
         if std::path::Path::new(format!("{}/{}", self.directory, self.name).as_str()).exists() {


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Action was throwing error due to no summary for me.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

Not to throw errors due to lack or summarization.

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`): v0.9.0
Operating system: macOS 15.1.1
