### PR TITLE
doc: Document new cli option for specifying configuration path

### DIFF
--- a/app/src/config/mod.rs
+++ b/app/src/config/mod.rs
@@ -16,6 +16,7 @@ pub struct GlobalArgs {
     #[arg(short = 'd', long)]
     pub manifest_directory: Option<String>,
 
+    /// Specify a configuration path (if invalid Comtrya will exit)
     #[arg(short = 'c', long)]
     pub config_path: Option<String>,
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -8,6 +8,9 @@ Comtrya works by running a manifest or set of manifests. The following are examp
 # Run all manifests within your current directory
 comtrya apply
 
+# Run all manifests within your current directory and a specified configuration file
+comtrya -c /path/to/Comtrya/yaml
+
 # --manifests, or -m, will run a subset of your manifests
 comtrya apply -m one,two,three
 


### PR DESCRIPTION
## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

## What is the current behaviour?
cli option -c provides users the option to specify a specific configuration file path

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
N/A

## What is the expected behavior?
N/A

## What is the motivation / use case for changing the behavior?
Adding documentation

## Please tell us about your environment:

Version (`comtrya --version`): comtrya 0.9.0
Operating system: MacOS
