### PR TITLE
fix(yay): Adds EndeavourOS to the yay list

### DIFF
--- a/lib/src/actions/package/providers/mod.rs
+++ b/lib/src/actions/package/providers/mod.rs
@@ -94,6 +94,7 @@ impl Default for PackageProviders {
             // Arch Variants
             os_info::Type::Arch=> PackageProviders::Yay,
             os_info::Type::Manjaro=> PackageProviders::Yay,
+            os_info::Type::EndeavourOS => PackageProviders::Yay,
             // BSD operating systems
             os_info::Type::DragonFly=> PackageProviders::BsdPkg,
             os_info::Type::FreeBSD=> PackageProviders::BsdPkg,


### PR DESCRIPTION
## I'm submitting a

- [X] bug fix


EndeavourOS is an arch upstream distribution, it's emitted by the library in question here but not currently matched against.