### PR TITLE
fix: purge "files" at the ignore walker phase instead of the final walk

### DIFF
--- a/lib/src/manifests/load.rs
+++ b/lib/src/manifests/load.rs
@@ -23,6 +23,10 @@ pub fn load(manifest_path: PathBuf, contexts: &Contexts) -> HashMap<String, Mani
         .same_file_system(true)
         // Arbitrary for now, 9 "should" be enough?
         .max_depth(Some(9))
+        .filter_entry(|entry| {
+            !(entry.metadata().map(|md| md.is_file()).unwrap_or(false)
+            && entry.file_name() == OsStr::new("files"))
+        })
         .build()
         // Don't walk directories
         .filter(|entry| {
@@ -41,18 +45,6 @@ pub fn load(manifest_path: PathBuf, contexts: &Contexts) -> HashMap<String, Mani
                     file_name.ends_with(".yaml")
                         || file_name.ends_with(".yml")
                         || file_name.ends_with(".toml")
-                })
-                .unwrap_or(false)
-        })
-        // Don't consider anything in a `files` directory a manifest
-        .filter(|entry| {
-            !entry
-                .as_ref()
-                .ok()
-                .and_then(|entry| {
-                    entry.path().parent().and_then(|parent| {
-                        parent.file_name().map(|file_name| file_name.eq("files"))
-                    })
                 })
                 .unwrap_or(false)
         })


### PR DESCRIPTION
## I'm submitting a

- [X] bug fix

## What is the current behaviour?
Files placed within `files` only get ignored as manifests if they are within the top level of `files`, the walker otherwise descends in to subdirectories and searches for manifests.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

1. Create a `files` folder for a manifest to source from
2. Create another folder within `files`, ie `files/foo`
3. Create a `.yml` or `.toml` file within the subfolder, ie `files/foo/some_config.yml`
4. Comtrya picks up this file as a manifest, and attempts to run it.

## What is the expected behavior?
`files` does not get descended into at all, so that yaml and toml based configs work as expected if they aren't at the top level of `files`

## What is the motivation / use case for changing the behavior?
Bitten by this on `.cargo/config.toml` and `.config/jj/config.toml`

This fixes it by filtering out `files` directories at the walker build step, preventing it from being descended into at all.

Ideal UX flow here would be to walk it anyways, search for potential manifests, and if a "manifest-like" file is found emit a warning that `files` is ignored by default, but this would require large refactors of surrounding area.
