### PR TITLE
fix: properly ignore files directory

### DIFF
--- a/lib/src/manifests/load.rs
+++ b/lib/src/manifests/load.rs
@@ -24,7 +24,7 @@ pub fn load(manifest_path: PathBuf, contexts: &Contexts) -> HashMap<String, Mani
         // Arbitrary for now, 9 "should" be enough?
         .max_depth(Some(9))
         .filter_entry(|entry| {
-            !(entry.metadata().map(|md| md.is_file()).unwrap_or(false)
+            !(entry.file_type().map_or(false, |ft| ft.is_dir())
             && entry.file_name() == OsStr::new("files"))
         })
         .build()


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Having YAML and TOML config files for other applications in subdirectories in the `files` directory, those are tried to be parsed by comtrya, resulting in a parsing error.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

Just place any YAML or TOML file in the `files` directory and e.g. run `comtrya status`. Comtrya tries to parse not only manifest files but also the files within this directory.

## What is the expected behavior?

Comtrya should ignore everything within the `files` directory while loading the manifests, as stated in the documentation.

## What is the motivation / use case for changing the behavior?

To make it works as expected.

## Please tell us about your environment:

Version (`comtrya --version`): 0.9.1
Operating system: macOS 15.1.1

Description:
This fixes ignoring the 'files' directory during walker ignore phase by fixing the check condition to actually check for a directory instead of a file.

Also improves the whole check by:
- using DirEntry::file_type() instead of Metadata::file_type() to avoid additional system calls
- replace the Option.map().unwrap_or() call with a more concise map_or() call.