### PR TITLE
implement summarize for user actions

### DIFF
--- a/lib/src/actions/user/add.rs
+++ b/lib/src/actions/user/add.rs
@@ -12,6 +12,10 @@ use tracing::debug;
 pub type UserAdd = User;
 
 impl Action for UserAdd {
+    fn summarize(&self) -> String {
+        format!("Adding user: {}", self.username)
+    }
+
     fn plan(&self, _manifest: &Manifest, context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let variant: UserVariant = self.into();
         let box_provider = variant.provider.clone().get_provider();

--- a/lib/src/actions/user/add_group.rs
+++ b/lib/src/actions/user/add_group.rs
@@ -21,6 +21,14 @@ pub struct UserAddGroup {
 }
 
 impl Action for UserAddGroup {
+    fn summarize(&self) -> String {
+        format!(
+            "Adding user {} to group(s) {}",
+            self.username,
+            self.group.join(",")
+        )
+    }
+
     fn plan(&self, _manifest: &Manifest, context: &Contexts) -> anyhow::Result<Vec<Step>> {
         let box_provider = self.provider.clone().get_provider();
         let provider = box_provider.deref();


### PR DESCRIPTION
## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

Output shows that the summarize functions are not implemented for user actions.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

In the tracing output have a proper summary for user actions.

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`): 0.9.1
Operating system: macOS 15.2
