### PR TITLE
fix(binary.github): added code to fetch the latest binary when version value passed is 'latest'

### DIFF
--- a/lib/src/actions/binary/github.rs
+++ b/lib/src/actions/binary/github.rs
@@ -57,13 +57,11 @@ impl Action for BinaryGitHub {
         let repos = octocrab.repos(owner, repo);
         let releases = repos.releases();
 
-
         let result = match &self.version {
             Some(version) if version == "latest" => async_runtime.block_on(releases.get_latest()),
             Some(version) => async_runtime.block_on(releases.get_by_tag(version.as_str())),
             None => async_runtime.block_on(releases.get_latest()),
         };
-
 
         let release = match result {
             Ok(release) => release,

--- a/lib/src/actions/binary/github.rs
+++ b/lib/src/actions/binary/github.rs
@@ -57,10 +57,13 @@ impl Action for BinaryGitHub {
         let repos = octocrab.repos(owner, repo);
         let releases = repos.releases();
 
+
         let result = match &self.version {
+            Some(version) if version == "latest" => async_runtime.block_on(releases.get_latest()),
             Some(version) => async_runtime.block_on(releases.get_by_tag(version.as_str())),
             None => async_runtime.block_on(releases.get_latest()),
         };
+
 
         let release = match result {
             Ok(release) => release,


### PR DESCRIPTION

## I'm submitting a

- [x] bug fix
- [ ] feature
- [ ] documentation addition

## What is the current behaviour?

This change pertains to when a github binary is being downloaded using comtrya. When the value of the version is **latest**,  it treats the version as the literal version rather than the logical meaning of it.

This issue is further described in the bug - https://github.com/comtrya/comtrya/issues/535 

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

1. Create a yaml file (**Comtrya.yaml**) with the following code - 

```
actions:
  - action: binary.github
    name: bat
    directory: /Users/sreerag-n/codes/github/comtrya/examples/binary
    repository: sharkdp/bat
    version: latest
```

2. Run the command to download the binary
```
comtrya apply
```
3. It will fail saying that it failed to find a release.


## What is the expected behavior?

When the version value passed is **latest**, it should fetch the latest version of the binary.

## What is the motivation / use case for changing the behaviour?
This fix addresses the bug raised in [this](https://github.com/comtrya/comtrya/issues/535) 

## Please tell us about your environment:

Version (`comtrya --version`): comtrya 0.9.1
Operating system: MacOS Sonoma 14.5
