### PR TITLE
Update documentation

### DIFF
--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -9,10 +9,10 @@ Comtrya works by running a manifest or set of manifests. Following are examples 
 comtrya apply
 
 # Run all manifests within your current directory and a specified configuration file
-comtrya -c /path/to/Comtrya/yaml
+comtrya -d ./ -c /path/to/Comtrya/yaml
 
 # --manifests, or -m, will run a subset of your manifests
-comtrya apply -m one,two,three
+comtrya -d ./ apply -m one,two,three
 
 # Run all manifests within a specified directory
 comtrya -d ./manifests apply

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -34,7 +34,7 @@ As shown, this is done with the `-d` option, which tells comtrya the directory t
 The second option is to specify specific manifest(s) to be executed:
 
 ```shell
-comtrya apply -m one,two,three
+comtrya -d ./ apply -m one,two,three
 ```
 
 The `-m` option is used to let comtrya know which manifests to apply. Note that the name of the manifest (i.e. one.yaml) is only the name and must not contain any path information or file extension (.yaml). So, `/manifests/one` is not a valid input. Any manifests are expected to be located in the directory of the manifests you specified.
@@ -43,19 +43,19 @@ Suppose you have a directory `manifests/` that contains the manifests `one.yaml`
 
 ```shell
 cd manifests/
-comtrya apply -m one
+comtrya -d ./ apply -m one
 ```
 
 Or you can specify the directory:
 
 ```shell
-comtrya -d manifests/one.yaml apply
+comtrya -d ./manifests/one.yaml apply
 ```
 
 Alternatively a combination of the two is possible as well:
 
 ```shell
-comtrya -d manifests/ apply -m one
+comtrya -d ./manifests/ apply -m one
 ```
 
 ## Contexts


### PR DESCRIPTION
fixes #567

## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

## What is the current behaviour?

```sh
comtrya apply -m domain.topic
comtrya apply
```

do not work unless you provide the directory

```sh
comtrya -d . apply -m domain.topic
comtrya -d . apply
```


## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`): 0.9.1
Operating system: Fedora 40
