### PR TITLE
Improve packages.repository sample

### DIFF
--- a/docs/src/packages.md
+++ b/docs/src/packages.md
@@ -63,10 +63,12 @@ Some package manager providers can implement a `bootstrap` method that will auto
   provider: pkgin
 
 # Install a package specifying a repository
-- action: package.install
-  name: blox
+- action: package.repository
   provider: homebrew
-  repository: cueblox/tap
+  name: foo-repository/formulae
+- action: package.install
+  name: foo
+  provider: homebrew
 ```
 
 ### Local package install support


### PR DESCRIPTION
Improve the documentation sample how to use custom repositories with homebrew

## I'm submitting a

- [ ] bug fix
- [ ] feature
- [x] documentation addition

## What is the current behaviour?
The documentation has an deprecated example for `package.install` with `repository` which was replaced by a combination of `package.repository` and a regular `package.install` call. 

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem

## What is the expected behavior?

## What is the motivation / use case for changing the behavior?

## Please tell us about your environment:

Version (`comtrya --version`):
Operating system:
