### PR TITLE
feat(ext_epics): per-repo epics slot in comtrya.cue

### DIFF
--- a/crates/server/comtrya.cue
+++ b/crates/server/comtrya.cue
@@ -46,4 +46,10 @@ projects: kernel: {
 		defaultLabels: ["kernel"]
 		closeOnMerge:  true
 	}
+
+	epics: {
+		defaultLabels:  ["kernel"]
+		defaultStatus:  "planned"
+		requiredFields: ["title"]
+	}
 }

--- a/extensions/first-party/ext_epics/manifest.json
+++ b/extensions/first-party/ext_epics/manifest.json
@@ -16,6 +16,12 @@
     "outputType": "comtrya.epics/summary.v1"
   },
   "contributes": {
+    "cueSchemas": [
+      {
+        "id": "epics",
+        "snippet": "package comtrya\n\n// Per-Project epic policy. The status set mirrors the WIT\n// `epic-state` variant exposed by ext_epics; if you add a state\n// here, also extend the variant. Read by ext_epics; the kernel\n// and other extensions do not interpret these fields.\n#EpicStatus: \"planned\" | \"in-progress\" | \"at-risk\" | \"done\" | \"canceled\"\n\n#EpicsPolicy: {\n  defaultLabels?:  [...string]\n  defaultStatus?:  #EpicStatus | *\"planned\"\n  requiredFields?: [...string]\n}\n\n#Project: { epics?: #EpicsPolicy }\n"
+      }
+    ],
     "resourceKinds": [{ "name": "epic", "prefix": "epc" }],
     "relationshipTypes": [
       {


### PR DESCRIPTION
## Plan

Add a `cueSchemas` declaration to `ext_epics/manifest.json` so the per-Project `epics` slot lives in the repo's CUE Comtrya package, matching the pattern already shipped by `ext_docs`, `ext_issues`, and `ext_pull_requests`.

The CUE schema declares:

- `#EpicStatus` — string union that mirrors the WIT `epic-state` variant (`planned | in-progress | at-risk | done | canceled`). If a state is added on either side, the other must be updated too; treating the CUE union as the contract makes that constraint visible to repo authors.
- `#EpicsPolicy` — `defaultLabels`, `defaultStatus` (defaulting to `"planned"`), `requiredFields`.
- `#Project: { epics?: #EpicsPolicy }` — extends `#Project` so any repo can opt-in.

`crates/server/comtrya.cue` (the kernel's own per-repo package) is updated to dogfood the slot.

## Survey context

While surveying for this iteration, three of the six first-party extensions ship a per-Project `cueSchemas` block, and three do not:

| Extension | per-repo CUE slot |
|---|---|
| ext_docs | yes |
| ext_issues | yes |
| ext_pull_requests | yes |
| ext_epics | **this PR** |
| ext_checks | not yet |
| ext_workspace_home | not yet |

`ext_checks` and `ext_workspace_home` to be picked up by subsequent loop iterations.

## Out of scope / next slices

- Wiring the new `epics` policy through to the `ext_epics` backend (consuming `defaultLabels` / `defaultStatus` / `requiredFields` at open-epic time). Schema first, behavior next, to keep this PR reviewable.
- Test coverage for `cue_config::evaluate_repo_config` against the new slot. The server bin's test target has pre-existing compile errors on `v3` (missing `cue_schemas` field initializer in `crates/server/src/main.rs:8475` and missing fields in `OpenIssueInput` at `crates/server/src/wasm_host.rs:1988`); fixing those is a separate slice.

## Test plan

- [ ] CI: server binary compiles (`cargo check -p comtrya-server` passes locally)
- [ ] CI: clippy with `-D warnings`
- [ ] Manual: `./start.sh --reset --oneshot` evaluates the kernel's `comtrya.cue` without a CUE error after the new `epics:` block is added

This PR was created with the assistance of a LLM.