### PR TITLE
fix(server): reject anonymous principals on graphql mutations (P0-1a)

### DIFF
--- a/crates/server/src/cue_config.rs
+++ b/crates/server/src/cue_config.rs
@@ -277,12 +277,8 @@ fn materialise_worktree(git_dir: &Path, ref_name: &str) -> Result<PathBuf, Strin
         .duration_since(UNIX_EPOCH)
         .map(|d| d.subsec_nanos())
         .unwrap_or(0);
-    let base = std::env::temp_dir().join(format!(
-        "comtrya-cue-{}-{nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&base)
-        .map_err(|e| format!("mkdir {} failed: {e}", base.display()))?;
+    let base = std::env::temp_dir().join(format!("comtrya-cue-{}-{nanos}", std::process::id()));
+    std::fs::create_dir_all(&base).map_err(|e| format!("mkdir {} failed: {e}", base.display()))?;
 
     let archive = Command::new("git")
         .arg("--git-dir")
@@ -294,7 +290,9 @@ fn materialise_worktree(git_dir: &Path, ref_name: &str) -> Result<PathBuf, Strin
         .spawn()
         .map_err(|e| format!("git archive spawn failed: {e}"))?;
 
-    let archive_out = archive.stdout.ok_or_else(|| "git archive stdout missing".to_string())?;
+    let archive_out = archive
+        .stdout
+        .ok_or_else(|| "git archive stdout missing".to_string())?;
     let status = Command::new("tar")
         .arg("-x")
         .arg("-C")
@@ -314,8 +312,7 @@ fn install_schemas(workdir: &Path, extension_schemas: &[ExtensionSchema]) -> Res
     let module_path = workdir.join("cue.mod").join("module.cue");
     if !module_path.is_file() {
         if let Some(parent) = module_path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("mkdir cue.mod failed: {e}"))?;
+            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir cue.mod failed: {e}"))?;
         }
         std::fs::write(
             &module_path,
@@ -339,11 +336,8 @@ fn install_schemas(workdir: &Path, extension_schemas: &[ExtensionSchema]) -> Res
     // `01-comtrya-ext-<id>-<schema>.cue`) so they don't collide with
     // any user-authored CUE at the workdir root and to keep ordering
     // stable in `cue export` output.
-    std::fs::write(
-        workdir.join("00-comtrya-kernel.cue"),
-        KERNEL_CUE_BASE,
-    )
-    .map_err(|e| format!("write kernel base schema failed: {e}"))?;
+    std::fs::write(workdir.join("00-comtrya-kernel.cue"), KERNEL_CUE_BASE)
+        .map_err(|e| format!("write kernel base schema failed: {e}"))?;
 
     for schema in extension_schemas {
         let safe_id = schema.schema_id.replace(['/', ' '], "-");
@@ -406,8 +400,8 @@ fn run_cuengine(workdir: &Path) -> Value {
             // match). In both cases the user sees the same outcome we
             // produce on a successful empty evaluation: one implicit
             // Project. Don't surface the noisy library text.
-            let benign = message.contains("matched no packages")
-                || message.contains("no CUE files");
+            let benign =
+                message.contains("matched no packages") || message.contains("no CUE files");
             json!({
                 "projects": [implicit_default_project()],
                 "repository": Value::Null,
@@ -436,7 +430,10 @@ fn discover_projects(instances: &[Value]) -> Vec<Value> {
             .unwrap_or("")
             .to_string();
         let value = instance.get("value");
-        let Some(map) = value.and_then(|v| v.get("projects")).and_then(Value::as_object) else {
+        let Some(map) = value
+            .and_then(|v| v.get("projects"))
+            .and_then(Value::as_object)
+        else {
             continue;
         };
         for (name, def) in map.iter() {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -892,11 +892,7 @@ impl Runtime {
         format!("comtrya://user-layout/{principal_uri}/{repository_id}")
     }
 
-    fn get_user_layout(
-        &self,
-        principal_uri: &str,
-        repository_id: &str,
-    ) -> Result<Value, String> {
+    fn get_user_layout(&self, principal_uri: &str, repository_id: &str) -> Result<Value, String> {
         let doc_id = Self::user_layout_document_id(principal_uri, repository_id);
         let collection = self.extension_storage.collection_data("user_layouts")?;
         let entries = collection
@@ -1641,6 +1637,12 @@ fn user_layout_query(state: AppState, headers: HeaderMap, payload: Value) -> Res
         Err(r) => return *r,
     };
     let principal = state.runtime.principal_context_from_headers(&headers);
+    // KNOWN-GAP(oidc-#16): `Anonymous` deliberately falls through here while
+    // the read path stays open until the frontend can authenticate. All
+    // anonymous callers share the `comtrya://principal/anonymous` URI, so
+    // they read the (empty) layout for that key — never another user's data.
+    // The sibling `user_layout_mutation` correctly rejects Anonymous because
+    // writes would clobber that shared key.
     if principal.status == PrincipalStatus::Invalid {
         return graphql_error_response(
             StatusCode::UNAUTHORIZED,
@@ -1682,17 +1684,11 @@ fn user_layout_mutation(state: AppState, headers: HeaderMap, payload: Value) -> 
         Err(r) => return *r,
     };
     let principal = state.runtime.principal_context_from_headers(&headers);
-    if matches!(
-        principal.status,
-        PrincipalStatus::Anonymous | PrincipalStatus::Invalid
-    ) {
-        return graphql_error_response(
-            StatusCode::UNAUTHORIZED,
-            ErrorCode::Unauthenticated.as_str(),
-            "setUserLayout requires an authenticated principal",
-            cors,
-        );
-    }
+    // TODO(oidc-#16): remove when auth check moves into graphql_guard
+    let cors = match require_authenticated_principal(principal.status, cors) {
+        Ok(c) => c,
+        Err(r) => return *r,
+    };
     let repository_id = payload
         .pointer("/variables/repositoryId")
         .and_then(Value::as_str)
@@ -1964,6 +1960,13 @@ fn comments_create_mutation(state: AppState, headers: HeaderMap, payload: Value)
         Ok(c) => c,
         Err(r) => return *r,
     };
+    // TODO(oidc-#16): remove when auth check moves into graphql_guard
+    let cors =
+        match require_authenticated_principal(state.runtime.principal_from_headers(&headers), cors)
+        {
+            Ok(c) => c,
+            Err(r) => return *r,
+        };
     let target = payload
         .pointer("/variables/input/target")
         .and_then(Value::as_str)
@@ -2010,6 +2013,13 @@ fn comments_update_mutation(state: AppState, headers: HeaderMap, payload: Value)
         Ok(c) => c,
         Err(r) => return *r,
     };
+    // TODO(oidc-#16): remove when auth check moves into graphql_guard
+    let cors =
+        match require_authenticated_principal(state.runtime.principal_from_headers(&headers), cors)
+        {
+            Ok(c) => c,
+            Err(r) => return *r,
+        };
     let id = payload
         .pointer("/variables/input/id")
         .and_then(Value::as_str)
@@ -2053,6 +2063,13 @@ fn comments_delete_mutation(state: AppState, headers: HeaderMap, payload: Value)
         Ok(c) => c,
         Err(r) => return *r,
     };
+    // TODO(oidc-#16): remove when auth check moves into graphql_guard
+    let cors =
+        match require_authenticated_principal(state.runtime.principal_from_headers(&headers), cors)
+        {
+            Ok(c) => c,
+            Err(r) => return *r,
+        };
     let id = payload
         .pointer("/variables/input/id")
         .and_then(Value::as_str)
@@ -2093,11 +2110,43 @@ pub(crate) fn graphql_guard(state: &AppState, headers: &HeaderMap) -> ResponseRe
     Ok(cors)
 }
 
+/// Reject `Anonymous` and `Invalid` principals on GraphQL mutation handlers.
+/// Preserves `cors` headers on the error response so cross-origin browsers
+/// receive a real 401 instead of an opaque CORS failure.
+///
+/// Read-path handlers and `/api/ops/*` are intentionally NOT gated here yet —
+/// the frontend SDK cannot authenticate until #16 (OIDC) ships. Each call site
+/// carries a `// TODO(oidc-#16):` marker so future centralization is grep-able.
+pub(crate) fn require_authenticated_principal(
+    principal: PrincipalStatus,
+    cors: HeaderMap,
+) -> ResponseResult<HeaderMap> {
+    if matches!(
+        principal,
+        PrincipalStatus::Anonymous | PrincipalStatus::Invalid
+    ) {
+        return Err(Box::new(graphql_error_response(
+            StatusCode::UNAUTHORIZED,
+            ErrorCode::Unauthenticated.as_str(),
+            "authentication required",
+            cors,
+        )));
+    }
+    Ok(cors)
+}
+
 fn relations_create_mutation(state: AppState, headers: HeaderMap, payload: Value) -> Response {
     let cors = match graphql_guard(&state, &headers) {
         Ok(c) => c,
         Err(r) => return *r,
     };
+    // TODO(oidc-#16): remove when auth check moves into graphql_guard
+    let cors =
+        match require_authenticated_principal(state.runtime.principal_from_headers(&headers), cors)
+        {
+            Ok(c) => c,
+            Err(r) => return *r,
+        };
     let from = payload
         .pointer("/variables/input/from")
         .and_then(Value::as_str)
@@ -2141,6 +2190,13 @@ fn relations_delete_mutation(state: AppState, headers: HeaderMap, payload: Value
         Ok(c) => c,
         Err(r) => return *r,
     };
+    // TODO(oidc-#16): remove when auth check moves into graphql_guard
+    let cors =
+        match require_authenticated_principal(state.runtime.principal_from_headers(&headers), cors)
+        {
+            Ok(c) => c,
+            Err(r) => return *r,
+        };
     let id = payload
         .pointer("/variables/input/id")
         .and_then(Value::as_str)
@@ -2272,16 +2328,17 @@ fn relations_between_query(state: AppState, headers: HeaderMap, payload: Value) 
 }
 
 fn create_repository_mutation(state: AppState, headers: HeaderMap, payload: Value) -> Response {
-    let cors = match state.runtime.check_boundary(&headers, "/graphql") {
-        Ok(cors) => cors,
-        Err(response) => return *response,
+    let cors = match graphql_guard(&state, &headers) {
+        Ok(c) => c,
+        Err(r) => return *r,
     };
-    if let Err(response) = state.runtime.rate_limit(
-        "graphql",
-        state.runtime.config.rate_limits.graphql_per_principal,
-    ) {
-        return *response;
-    }
+    // TODO(oidc-#16): remove when auth check moves into graphql_guard
+    let cors =
+        match require_authenticated_principal(state.runtime.principal_from_headers(&headers), cors)
+        {
+            Ok(c) => c,
+            Err(r) => return *r,
+        };
     let path = payload
         .pointer("/variables/input/path")
         .and_then(Value::as_str)
@@ -3460,7 +3517,10 @@ fn apply_repository_cue_overrides(
         return;
     };
     if let Some(visibility) = repo_block.get("visibility").and_then(Value::as_str) {
-        repo_obj.insert("visibility".to_string(), json!(visibility.to_ascii_uppercase()));
+        repo_obj.insert(
+            "visibility".to_string(),
+            json!(visibility.to_ascii_uppercase()),
+        );
     }
     if let Some(branch) = repo_block.get("defaultBranch").and_then(Value::as_str) {
         repo_obj.insert("defaultBranch".to_string(), json!(branch));
@@ -3528,10 +3588,7 @@ fn annotate_bookmarks_with_resolution(
     repo_obj: &mut serde_json::Map<String, Value>,
     git_dir: &Path,
 ) {
-    let Some(bookmarks) = repo_obj
-        .get_mut("bookmarks")
-        .and_then(Value::as_array_mut)
-    else {
+    let Some(bookmarks) = repo_obj.get_mut("bookmarks").and_then(Value::as_array_mut) else {
         return;
     };
     for bookmark in bookmarks.iter_mut() {
@@ -3849,8 +3906,7 @@ fn git_demo_snapshot(
         &["diff", "--patch", "--find-renames", "main~1", "main"],
     )
     .unwrap_or_default();
-    let comtrya_config =
-        cue_config::evaluate_repo_config(&repo.git_dir, "main", extension_schemas);
+    let comtrya_config = cue_config::evaluate_repo_config(&repo.git_dir, "main", extension_schemas);
     let mut repository = json!({
         "id": "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
         "owner": "comtrya",
@@ -4150,8 +4206,21 @@ fn is_text_preview_path(path: &str) -> bool {
         Path::new(path)
             .extension()
             .and_then(|extension| extension.to_str()),
-        Some("md" | "mdx" | "rs" | "ts" | "tsx" | "js" | "jsx" | "vue"
-            | "json" | "toml" | "cue" | "yaml" | "yml" | "txt")
+        Some(
+            "md" | "mdx"
+                | "rs"
+                | "ts"
+                | "tsx"
+                | "js"
+                | "jsx"
+                | "vue"
+                | "json"
+                | "toml"
+                | "cue"
+                | "yaml"
+                | "yml"
+                | "txt"
+        )
     )
 }
 
@@ -6371,6 +6440,21 @@ mod tests {
         headers
     }
 
+    /// Headers carrying the default test `Origin` so `check_boundary` populates
+    /// `Access-Control-Allow-Origin` on the response. Required by any test that
+    /// asserts CORS-header presence on 4xx responses.
+    fn origin_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", HeaderValue::from_static("http://localhost:4321"));
+        headers
+    }
+
+    fn bearer_headers_with_origin(token: &str) -> HeaderMap {
+        let mut headers = bearer_headers(token);
+        headers.insert("origin", HeaderValue::from_static("http://localhost:4321"));
+        headers
+    }
+
     async fn call_api_op(
         state: AppState,
         headers: HeaderMap,
@@ -8237,7 +8321,10 @@ extensions: {
             "contributes": { "slots": ["bogus"], "routes": false }
         });
         let result = validate_ui_manifest_from_value(&v2);
-        assert!(result.is_ok(), "legacy contributes block must not fail validation: {result:?}");
+        assert!(
+            result.is_ok(),
+            "legacy contributes block must not fail validation: {result:?}"
+        );
     }
 
     #[test]
@@ -8450,21 +8537,222 @@ extensions: {
 
     #[tokio::test]
     async fn set_user_layout_rejects_anonymous_principal() {
+        // Uses the shared helper so the assertion set (401, CORS header,
+        // typed `unauthenticated` error code) is identical across every
+        // mutation-rejection test in this file.
+        assert_mutation_rejects_anonymous(
+            "mutation { setUserLayout(repositoryId: \"r\", layout: { entries: {} }) { repositoryId } }",
+            json!({ "repositoryId": "r", "layout": { "entries": {} } }),
+        )
+        .await;
+    }
+
+    // ---- P0-1a: anonymous-rejection on GraphQL mutation handlers (issue #4) ----
+
+    async fn assert_mutation_rejects_anonymous(query: &str, variables: Value) {
         let runtime = dev_runtime_no_extensions();
         let response = graphql_post(
             State(AppState {
                 runtime,
                 git_state: PureRustGitState::test_default(),
             }),
-            HeaderMap::new(),
+            origin_headers(),
+            json!({ "query": query, "variables": variables }).to_string(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "anonymous request to mutation `{query}` must be 401"
+        );
+        assert!(
+            response
+                .headers()
+                .contains_key("access-control-allow-origin"),
+            "401 must preserve CORS so the browser reads the body, not surface a CORS error",
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let payload = serde_json::from_slice::<Value>(&body).unwrap();
+        assert_eq!(
+            payload["errors"][0]["extensions"]["code"],
+            ErrorCode::Unauthenticated.as_str(),
+            "error envelope must use the typed Unauthenticated code",
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_create_repository_rejects_anonymous() {
+        assert_mutation_rejects_anonymous(
+            "mutation($input: CreateRepositoryInput!) { createRepository(input: $input) { repository { path } } }",
+            json!({ "input": { "path": "x/anonymous-poke" } }),
+        )
+        .await;
+    }
+
+    // The dispatch table uses dotted-field GraphQL identifiers
+    // (`relations.create`, `comments.create`, …); the SDK and frontend send
+    // queries in the same shape. Mirror that exactly in tests so they
+    // actually reach the targeted handler.
+
+    #[tokio::test]
+    async fn graphql_relations_create_rejects_anonymous() {
+        assert_mutation_rejects_anonymous(
+            "mutation($input: RelationCreateInput!) { relations.create(input: $input) { id } }",
+            json!({ "input": { "from": "a", "to": "b", "kind": "k" } }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn graphql_relations_delete_rejects_anonymous() {
+        assert_mutation_rejects_anonymous(
+            "mutation($input: RelationDeleteInput!) { relations.delete(input: $input) }",
+            json!({ "input": { "id": "r_anything" } }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn graphql_comments_create_rejects_anonymous() {
+        assert_mutation_rejects_anonymous(
+            "mutation($input: CommentCreateInput!) { comments.create(input: $input) { id } }",
+            json!({ "input": { "target": "issue:1", "body": "hi" } }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn graphql_comments_update_rejects_anonymous() {
+        assert_mutation_rejects_anonymous(
+            "mutation($input: CommentUpdateInput!) { comments.update(input: $input) { id } }",
+            json!({ "input": { "id": "c_1", "body": "edited" } }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn graphql_comments_delete_rejects_anonymous() {
+        assert_mutation_rejects_anonymous(
+            "mutation($input: CommentDeleteInput!) { comments.delete(input: $input) }",
+            json!({ "input": { "id": "c_1" } }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn graphql_create_repository_rejects_invalid_token() {
+        let runtime = dev_runtime_no_extensions();
+        let response = graphql_post(
+            State(AppState {
+                runtime,
+                git_state: PureRustGitState::test_default(),
+            }),
+            bearer_headers_with_origin("not-a-real-token"),
             json!({
-                "query": "mutation { setUserLayout(repositoryId: \"r\", layout: { entries: {} }) { repositoryId } }",
-                "variables": { "repositoryId": "r", "layout": { "entries": {} } }
+                "query": "mutation($input: CreateRepositoryInput!) { createRepository(input: $input) { repository { path } } }",
+                "variables": { "input": { "path": "x/invalid-poke" } }
             })
             .to_string(),
         )
         .await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            response
+                .headers()
+                .contains_key("access-control-allow-origin"),
+            "401 on Invalid bearer must preserve CORS too",
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_create_repository_succeeds_with_operator_credential() {
+        // TEST-COUPLING CAVEAT: this happy-path test uses the operator-code credential,
+        // which is slated for removal in #16 (OIDC epic). When that lands, replace the
+        // `issue_credential(... OperatorCredential)` call with whatever stub the OIDC
+        // verifier exposes for tests.
+        let runtime = dev_runtime_no_extensions();
+        let token = runtime.issue_credential(
+            "comtrya://workspace".to_string(),
+            vec!["graphql:write".to_string()],
+            PrincipalStatus::OperatorCredential,
+        );
+        let response = graphql_post(
+            State(AppState {
+                runtime,
+                git_state: PureRustGitState::test_default(),
+            }),
+            bearer_headers_with_origin(&token),
+            json!({
+                "query": "mutation($input: CreateRepositoryInput!) { createRepository(input: $input) { repository { path } } }",
+                "variables": { "input": { "path": "x/authenticated-poke" } }
+            })
+            .to_string(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "authenticated mutation must not be false-positive-401'd by the new gate"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let payload = serde_json::from_slice::<Value>(&body).unwrap();
+        assert!(
+            payload["data"]["createRepository"]["repository"]["path"].is_string(),
+            "happy-path response must carry a real repository payload, not just OK with an error envelope: {payload:?}"
+        );
+    }
+
+    /// DEFERRED-BY-DESIGN: anonymous reads remain open until OIDC ships (#16).
+    /// This test pins that behavior so a future "centralize auth in graphql_guard"
+    /// refactor cannot silently lock the read path without a coordinated frontend
+    /// change. DELETE THIS TEST as part of the #16 PR.
+    #[tokio::test]
+    async fn graphql_comments_thread_still_allows_anonymous() {
+        let runtime = dev_runtime_no_extensions();
+        let response = graphql_post(
+            State(AppState {
+                runtime,
+                git_state: PureRustGitState::test_default(),
+            }),
+            origin_headers(),
+            json!({
+                "query": "query($target: ID!) { comments.thread(target: $target) { id } }",
+                "variables": { "target": "issue:1" }
+            })
+            .to_string(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "anonymous reads must stay open until OIDC ships (#16)",
+        );
+    }
+
+    /// DEFERRED-BY-DESIGN: anonymous reads remain open until OIDC ships (#16).
+    /// Mirrors the exact `workspace { ... }` shape `App.vue:loadShellSummary` sends
+    /// so a future read-path lockdown would break this test (and the shell) together.
+    /// DELETE THIS TEST as part of the #16 PR.
+    #[tokio::test]
+    async fn graphql_query_workspace_still_allows_anonymous() {
+        let runtime = dev_runtime_no_extensions();
+        let response = graphql_post(
+            State(AppState {
+                runtime,
+                git_state: PureRustGitState::test_default(),
+            }),
+            origin_headers(),
+            json!({
+                "query": "query { workspace { id name } }"
+            })
+            .to_string(),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "anonymous workspace query must stay open until OIDC ships (#16)",
+        );
     }
 
     #[tokio::test]
@@ -8643,6 +8931,7 @@ extensions: {
                 root: PathBuf::new(),
                 ui_manifest: PathBuf::new(),
                 route_prefix: Some("pulls".to_string()),
+                cue_schemas: Vec::new(),
             },
         );
         let result = inject_route_prefix(extensions, &configs, &runtime);

--- a/crates/server/src/wasm_host.rs
+++ b/crates/server/src/wasm_host.rs
@@ -1989,6 +1989,10 @@ mod m1_ext_issues_smoke {
             repository: "comtrya://workspace/ws_test/repository/repo_test".into(),
             title: "M1 smoke".into(),
             body_markdown: "test body".into(),
+            project_name: None,
+            labels: vec![],
+            close_on_merge: None,
+            assignees: vec![],
         };
         let opened = issues
             .comtrya_ext_issues_issues()


### PR DESCRIPTION
Closes #4 (P0-1a only — see "Scope" below; the remainder of issue #4 is split across separate items already tracked there).

## Summary

Reject `Anonymous` and `Invalid` principals on every state-mutating GraphQL handler, preserving CORS headers on the 401 response so browsers receive a real error instead of an opaque CORS failure. Mutation surface gated in this PR: `createRepository`, `relations.create`, `relations.delete`, `comments.create`, `comments.update`, `comments.delete`, `setUserLayout`.

## Why this is narrower than issue #4 says

Three rounds of adversarial planning review uncovered that the frontend has no auth mechanism today — the SDK's GraphQL client (`frontend/packages/sdk-core/src/graphql-client.ts`) and the `api_op` invoker (`frontend/packages/sdk-core/src/runtime.ts`) both send unauthenticated requests on cold load. Locking GraphQL **reads** or `/api/ops/*` against `Anonymous` would 401 the shell on every cold load (`App.vue:loadShellSummary`, `extension-loader.ts:loadShellExtensions`, `Repos.vue`, `InstanceHealth.vue`, `WorkspaceHome.vue`) and every extension panel (`IssuesList.vue:list-issues`, `PullsQueue.vue:list-pulls`, `EpicsList.vue:list-epics`, `PullsDetail.vue:get-pull`, `api.ts:by-ref-issue`).

This PR therefore narrows P0-1 to its mutation half — paths the frontend never hits anonymously — and defers the read-path lockdown plus all of `/api/ops/*` to **#16** (OIDC epic, filed during planning), which delivers the OIDC flow and lets the SDK bear a token. Two deferred-by-design pin tests in this PR explicitly assert that anonymous reads still return 200; they carry inline `DELETE THIS TEST as part of the #16 PR` markers.

Each per-site gate carries a `// TODO(oidc-#16):` marker so #16 can grep-and-remove them when it centralizes the check into `graphql_guard`.

## Acceptance criteria (subset of issue #4)

- [x] **P0-1 (mutation half)** — anonymous POST to `/graphql` with any of the 7 mutations above returns 401 with `code: "UNAUTHENTICATED"` and `Access-Control-Allow-Origin` preserved.
- [x] **CORS preservation on 401** — verified by tests asserting `access-control-allow-origin` header presence; tests use the new `origin_headers()` helper since `check_boundary` only echoes the header when `Origin` is present in the request.
- [x] **No false positives** — happy-path test confirms an authenticated `OperatorCredential` session can still `createRepository`.
- [x] **Read paths unchanged** — `graphql_response`, `user_layout_query`, `comments.thread`, `relations.outgoing/incoming/between`, GET `/graphql`, and all of `/api/ops/*` continue to accept Anonymous. Pinned by two regression tests.
- [ ] **P0-1 (read half + api_op)** — deferred to #16.
- [ ] **P0-2 `DefaultAuthz`** — out of scope (separate issue #4 item). After this PR, authenticated callers still pass through `DefaultAuthz::has_permission → Some(true)`.
- [ ] **P0-3 token format** — out of scope.
- [ ] **P1-5 per-principal rate limit** — out of scope; rate limit still runs before the auth check (matches pre-existing ordering).
- [ ] **P1-6 body size limits** — out of scope.
- [ ] **P2-5 / P2-6 readyz scoping, security headers** — out of scope.
- [ ] **P2-9 operator-code grant removal** — out of scope; the new happy-path test still uses `OperatorCredential`, with an inline coupling caveat pointing to #16.

## How it works

Central helper in `crates/server/src/main.rs`:

```rust
pub(crate) fn require_authenticated_principal(
    principal: PrincipalStatus,
    cors: HeaderMap,
) -> ResponseResult<HeaderMap> {
    if matches!(principal, PrincipalStatus::Anonymous | PrincipalStatus::Invalid) {
        return Err(Box::new(graphql_error_response(
            StatusCode::UNAUTHORIZED,
            ErrorCode::Unauthenticated.as_str(),
            "authentication required",
            cors,
        )));
    }
    Ok(cors)
}
```

Called per-site (with a `// TODO(oidc-#16):` marker) immediately after `graphql_guard` returns. `user_layout_mutation`'s pre-existing handler-local `matches!(_, Anonymous | Invalid)` check was deleted in favor of the helper. `create_repository_mutation` was normalized to use `graphql_guard` (it previously inlined `check_boundary` + `rate_limit`).

`user_layout_query` is the one read handler that retains its `Invalid`-only check and carries a `// KNOWN-GAP(oidc-#16):` marker explaining the asymmetry — all anonymous callers share `comtrya://principal/anonymous` for layout reads, which is harmless because the mutation correctly rejects writes to that key.

## Test Plan

11 tests in `crates/server/src/main.rs` (8 new + 1 enhanced + 2 deferred-pins):

- [x] `graphql_create_repository_rejects_anonymous`
- [x] `graphql_relations_create_rejects_anonymous`
- [x] `graphql_relations_delete_rejects_anonymous`
- [x] `graphql_comments_create_rejects_anonymous`
- [x] `graphql_comments_update_rejects_anonymous`
- [x] `graphql_comments_delete_rejects_anonymous`
- [x] `set_user_layout_rejects_anonymous_principal` (refactored to use the shared `assert_mutation_rejects_anonymous` helper)
- [x] `graphql_create_repository_rejects_invalid_token` (regression guard for the existing `Invalid`-only path + CORS on Invalid)
- [x] `graphql_create_repository_succeeds_with_operator_credential` (happy path — no false positive)
- [x] `graphql_comments_thread_still_allows_anonymous` (deferred-by-design pin — delete in #16)
- [x] `graphql_query_workspace_still_allows_anonymous` (deferred-by-design pin — mirrors `App.vue:loadShellSummary`'s exact query shape)

Run:

```
cargo test --bin comtrya-server -- --test-threads=4 graphql_create_repository graphql_relations graphql_comments graphql_query_workspace_still graphql_comments_thread_still set_user_layout_rejects
# → 11 passed; 0 failed
```

Workspace-level (local runs at commit time; CI will re-verify on push):

- `cargo clippy --workspace -- -D warnings` — clean. No `#[allow(...)]` added.
- `cargo fmt --check` — clean.

## Honest disclosures

1. **Precondition fixes bundled in this PR.** v3 HEAD's test suite did not compile (`OpenIssueInput` and `ExtensionRuntimeRecord` test fixtures missing fields added to the underlying types/WIT). Fixed inline so this PR's tests can run. Two trivial additions:
   - `crates/server/src/wasm_host.rs` — `OpenIssueInput { …, project_name: None, labels: vec![], close_on_merge: None, assignees: vec![] }`.
   - `crates/server/src/main.rs:8941` — `ExtensionRuntimeRecord { …, cue_schemas: Vec::new() }`.
2. **Incidental `cargo fmt` reflow of `crates/server/src/cue_config.rs`** (~14 insertions / ~17 deletions, formatting only). The file was not fmt-clean on v3 HEAD; bundled here so CI's `cargo fmt --check` passes. Pure whitespace.
3. **18 pre-existing v3 test failures** unrelated to this change (extension manifest / WIT / runtime registry refactor). Confirmed via `git stash` — they exist on clean v3 HEAD and would have surfaced as soon as anyone fixed the compile errors above. Not in scope for this PR.
4. **No browser verification performed.** The CLAUDE.md UI Verification Hard Rule applies to changes affecting rendered UI. This PR is server-only with no Vue/TS/asset changes. Anonymous reads — what the frontend actually hits on cold load — are explicitly unchanged. Mutations were already failing for anonymous callers from the browser's perspective via SDK behavior; this PR just enforces it server-side. The new tests assert HTTP-level Response shape (status, CORS header, error code) which is the same surface the browser sees.

## Process trail

- Stage 1 (planning) — 3 rounds of adversarial review. Round 1 caught the frontend-cannot-authenticate problem; Round 2 caught the same problem on `api_op` and a CORS-test-vacuous-assertion bug; Round 3 SHIPped.
- Stage 2 (TDD + implementation) — 2 rounds. Round 1 reviewer #1 SHIP; reviewer #2 REVISE on `user_layout_query` Anonymous gap, test helper asymmetry, and `create_repository_mutation` not using `graphql_guard`. All fixed in Round 2; both reviewers SHIP.
- Stage 3 (final review) — 3 reviewers (acceptance / regressions / PR description honesty) pending at PR open.
