### PR TITLE
fix(core): real CUE evaluation for receive-pack config validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,10 @@ dependencies = [
 [[package]]
 name = "comtrya-core"
 version = "0.1.0"
+dependencies = [
+ "cuengine",
+ "tempfile",
+]
 
 [[package]]
 name = "comtrya-extension-oci"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,3 +4,5 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+cuengine = "0.40"
+tempfile = "3"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -283,10 +283,16 @@ impl Default for PublisherCeilings {
     }
 }
 
+/// Caps applied to user-supplied CUE files before invoking the
+/// cuengine evaluator. `wall_time_ms` and `memory_bytes` used to live
+/// on this struct but were never enforced; deleted to satisfy the
+/// no-dead-code rule. Wiring a real time/memory cap around the
+/// cuengine FFI call is tracked as a separate follow-up — until that
+/// lands, the only protections against pathological CUE inputs are
+/// `max_files` / `max_depth` / `max_bytes` and whatever process-level
+/// quotas the OS imposes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CueEvalBudget {
-    pub wall_time_ms: u64,
-    pub memory_bytes: u64,
     pub max_files: usize,
     pub max_depth: usize,
     pub max_bytes: usize,
@@ -295,8 +301,6 @@ pub struct CueEvalBudget {
 impl Default for CueEvalBudget {
     fn default() -> Self {
         Self {
-            wall_time_ms: 5_000,
-            memory_bytes: 256_000_000,
             max_files: 1_024,
             max_depth: 16,
             max_bytes: 8_000_000,
@@ -386,7 +390,7 @@ pub fn validate_repository_cue_sources(
 
     let mut diagnostics = Vec::new();
     let mut paths = BTreeSet::from(["/".to_string()]);
-    for file in comtrya_files {
+    for file in &comtrya_files {
         if !balanced_braces(&file.source) {
             diagnostics.push(ConfigDiagnostic {
                 severity: "error".to_string(),
@@ -394,16 +398,20 @@ pub fn validate_repository_cue_sources(
                 message: "CUE braces are not balanced".to_string(),
             });
         }
-        if file.source.contains("invalid: true") || file.source.contains("!!") {
-            diagnostics.push(ConfigDiagnostic {
-                severity: "error".to_string(),
-                path: Some(file.path.clone()),
-                message: "repository CUE is invalid".to_string(),
-            });
-        }
         if let Some(parent) = parent_path_for_cue(&file.path) {
             paths.insert(parent);
         }
+    }
+
+    // `balanced_braces` tracks only `{`/`}` (NOT `[`, `(`, quotes), so it
+    // only catches a narrow class of obvious curly-brace mismatches with a
+    // friendlier message. Everything else falls through to cuengine — the
+    // real CUE evaluator — which catches type conflicts, constraint
+    // violations, and full parse errors.
+    if diagnostics.is_empty()
+        && let Err(diagnostic) = evaluate_cue_files_with_cuengine(&comtrya_files)
+    {
+        diagnostics.push(diagnostic);
     }
 
     if !diagnostics.is_empty() {
@@ -436,6 +444,164 @@ pub fn validate_repository_cue_sources(
         diagnostics: Vec::new(),
         snapshots,
     })
+}
+
+/// Run cuengine over the user's `package comtrya` files in an ephemeral
+/// workdir and return `Ok(())` on success, `Err(diagnostic)` on a real
+/// CUE evaluation failure.
+///
+/// Path sanitization happens FIRST, before any filesystem touch — any
+/// `CueFile::path` that is absolute or contains a `..` component is
+/// rejected with no tempdir created. Without this, a crafted push could
+/// write to arbitrary host paths via `tempdir.join("../../etc/...")`.
+///
+/// On cuengine error, the diagnostic message has the tempdir path
+/// stripped (cuengine emits the absolute workdir; leaking it to a
+/// GraphQL client is information disclosure).
+///
+/// Known limitation tracked as a follow-up: this validator does not load
+/// `KERNEL_CUE_BASE` or extension schemas into the workdir, so violations
+/// of kernel-declared required fields are NOT caught here. Only in-file
+/// type unification and constraint failures are.
+fn evaluate_cue_files_with_cuengine(files: &[&CueFile]) -> Result<(), ConfigDiagnostic> {
+    use std::path::{Component, Path};
+
+    // 1. Sanitize EVERY path before touching the filesystem.
+    //    Rejects:
+    //    a. absolute paths and `..` components — would write outside the
+    //       tempdir entirely;
+    //    b. anything under `cue.mod/` — would overwrite the synthetic
+    //       `cue.mod/module.cue` the helper writes in step 3, letting a
+    //       crafted push replace the module declaration cuengine
+    //       evaluates against and silently corrupt the validation result.
+    for file in files {
+        let p = Path::new(&file.path);
+        if p.is_absolute() || p.components().any(|c| matches!(c, Component::ParentDir)) {
+            return Err(ConfigDiagnostic {
+                severity: "error".to_string(),
+                path: Some(file.path.clone()),
+                message: "CUE file path escapes the repository workdir".to_string(),
+            });
+        }
+        if file.path == "cue.mod/module.cue" || file.path.starts_with("cue.mod/") {
+            return Err(ConfigDiagnostic {
+                severity: "error".to_string(),
+                path: Some(file.path.clone()),
+                message: "CUE file path must not write into cue.mod/ — that directory is reserved for the synthetic module declaration".to_string(),
+            });
+        }
+    }
+
+    // 2. Tempdir scoped to this validation call. Use a non-dot prefix —
+    //    CUE's package loader walks `./...` and skips directories whose
+    //    *name* starts with `.` (the Go convention). `tempfile::TempDir`
+    //    defaults to a `.tmpXXXX` name, which would make cuengine
+    //    silently match zero packages even though the workdir contents
+    //    are correct. Explicit `comtrya-cue-` prefix avoids that.
+    let dir = match tempfile::Builder::new().prefix("comtrya-cue-").tempdir() {
+        Ok(d) => d,
+        Err(e) => {
+            return Err(ConfigDiagnostic {
+                severity: "error".to_string(),
+                path: None,
+                message: format!("create cuengine workdir: {e}"),
+            });
+        }
+    };
+    let workdir = dir.path();
+
+    // 3. Synthetic cue.mod/module.cue — matches the server's
+    //    install_schemas synthetic exactly so the two paths stay aligned.
+    let module_dir = workdir.join("cue.mod");
+    if let Err(e) = std::fs::create_dir_all(&module_dir) {
+        return Err(ConfigDiagnostic {
+            severity: "error".to_string(),
+            path: None,
+            message: format!("write cuengine cue.mod: {e}"),
+        });
+    }
+    if let Err(e) = std::fs::write(
+        module_dir.join("module.cue"),
+        // Match the server's `install_schemas` synthetic exactly — same
+        // module name, same language version, same CUE shorthand syntax
+        // — so the receive-pack validator and the per-repo browser stay
+        // semantically aligned.
+        "module: \"comtrya.synthesised/repo\"\nlanguage: version: \"v0.10.0\"\n",
+    ) {
+        return Err(ConfigDiagnostic {
+            severity: "error".to_string(),
+            path: None,
+            message: format!("write cuengine module.cue: {e}"),
+        });
+    }
+
+    // 4. Write each user file to its sanitized relative path.
+    for file in files {
+        let dest = workdir.join(&file.path);
+        if let Some(parent) = dest.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            return Err(ConfigDiagnostic {
+                severity: "error".to_string(),
+                path: Some(file.path.clone()),
+                message: format!("write cuengine workdir dir: {e}"),
+            });
+        }
+        if let Err(e) = std::fs::write(&dest, &file.source) {
+            return Err(ConfigDiagnostic {
+                severity: "error".to_string(),
+                path: Some(file.path.clone()),
+                message: format!("write cuengine workdir file: {e}"),
+            });
+        }
+    }
+
+    // 5. Evaluate recursively across the whole workdir tree (matches the
+    //    server's `run_cuengine` shape). Third arg is
+    //    `Option<&ModuleEvalOptions>` so wrap in `Some`.
+    let options = cuengine::ModuleEvalOptions {
+        with_meta: false,
+        with_references: false,
+        recursive: true,
+        package_name: Some("comtrya".to_string()),
+        target_dir: None,
+    };
+    match cuengine::evaluate_module(workdir, "comtrya", Some(&options)) {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            let raw = format!("{error}");
+            // Match the server's `run_cuengine` benign-error policy: when
+            // cuengine reports "matched no packages" or "no CUE files",
+            // it means there was nothing for it to evaluate as a coherent
+            // package (e.g., subdirectories that contain no CUE files
+            // matching the package filter). The server treats this as
+            // success and the validator must too, or legitimate
+            // nested-CUE pushes are wrongly rejected.
+            if raw.contains("matched no packages") || raw.contains("no CUE files") {
+                return Ok(());
+            }
+            // Strip the absolute workdir path AND its canonicalized form
+            // — on macOS `/var/folders/...` is a symlink to
+            // `/private/var/folders/...` and cuengine may emit either
+            // form depending on its internal resolution. Scrubbing only
+            // one would leak the other.
+            let workdir_str = workdir.to_str().unwrap_or("");
+            let canonical = std::fs::canonicalize(workdir).ok();
+            let canonical_str = canonical.as_deref().and_then(|p| p.to_str()).unwrap_or("");
+            let mut message = raw;
+            if !workdir_str.is_empty() {
+                message = message.replace(workdir_str, "<workdir>");
+            }
+            if !canonical_str.is_empty() && canonical_str != workdir_str {
+                message = message.replace(canonical_str, "<workdir>");
+            }
+            Err(ConfigDiagnostic {
+                severity: "error".to_string(),
+                path: None,
+                message,
+            })
+        }
+    }
 }
 
 fn snapshot(
@@ -779,13 +945,16 @@ mod tests {
     }
 
     #[test]
-    fn repository_cue_invalid_package_is_rejected_with_diagnostics() {
+    fn repository_cue_conflicting_values_rejected() {
+        // `foo: "a"` then `foo: 42` unifies to a type conflict — a real CUE
+        // failure mode the legacy `"invalid: true"` string-match stub never
+        // caught.
         let result = validate_repository_cue_sources(
             "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
             "0123456789abcdef0123456789abcdef01234567",
             &[CueFile {
                 path: "comtrya.cue".to_string(),
-                source: "package comtrya\ninvalid: true".to_string(),
+                source: "package comtrya\nfoo: \"a\"\nfoo: 42".to_string(),
             }],
             &CueEvalBudget::default(),
         )
@@ -793,6 +962,163 @@ mod tests {
 
         assert!(!result.accepted);
         assert_eq!(result.diagnostics[0].severity, "error");
+    }
+
+    #[test]
+    fn repository_cue_constraint_violation_rejected() {
+        // `count: int & <3` then `count: 5` — CUE constraint solver rejects.
+        let result = validate_repository_cue_sources(
+            "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
+            "0123456789abcdef0123456789abcdef01234567",
+            &[CueFile {
+                path: "comtrya.cue".to_string(),
+                source: "package comtrya\ncount: int & <3\ncount: 5".to_string(),
+            }],
+            &CueEvalBudget::default(),
+        )
+        .unwrap();
+
+        assert!(!result.accepted);
+        assert_eq!(result.diagnostics[0].severity, "error");
+    }
+
+    #[test]
+    fn repository_cue_invalid_syntax_rejected() {
+        // Unclosed `[` — `balanced_braces` only tracks `{`/`}`, so this
+        // falls through to cuengine, which catches it as a parse error.
+        let result = validate_repository_cue_sources(
+            "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
+            "0123456789abcdef0123456789abcdef01234567",
+            &[CueFile {
+                path: "comtrya.cue".to_string(),
+                source: "package comtrya\nfoo: [".to_string(),
+            }],
+            &CueEvalBudget::default(),
+        )
+        .unwrap();
+
+        assert!(!result.accepted);
+        assert_eq!(result.diagnostics[0].severity, "error");
+    }
+
+    #[test]
+    fn repository_cue_unbalanced_braces_caught_by_smoke_check() {
+        // Unbalanced `{` — caught by the fast-fail `balanced_braces` walker
+        // before cuengine is invoked, yielding the friendlier message.
+        let result = validate_repository_cue_sources(
+            "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
+            "0123456789abcdef0123456789abcdef01234567",
+            &[CueFile {
+                path: "comtrya.cue".to_string(),
+                source: "package comtrya\nfoo: {".to_string(),
+            }],
+            &CueEvalBudget::default(),
+        )
+        .unwrap();
+
+        assert!(!result.accepted);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("braces are not balanced")),
+            "expected the friendlier brace-check message; got: {:?}",
+            result.diagnostics,
+        );
+    }
+
+    #[test]
+    fn repository_cue_path_traversal_rejected() {
+        // A push that names a file path escaping the repository workdir
+        // (absolute path or `..` components) must be refused before any
+        // filesystem write happens — defense against arbitrary-file-write.
+        for path in ["../../etc/passwd", "/etc/passwd", "a/../../etc/passwd"] {
+            let result = validate_repository_cue_sources(
+                "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
+                "0123456789abcdef0123456789abcdef01234567",
+                &[CueFile {
+                    path: path.to_string(),
+                    source: "package comtrya".to_string(),
+                }],
+                &CueEvalBudget::default(),
+            )
+            .unwrap();
+            assert!(
+                !result.accepted,
+                "path `{path}` must be rejected as escaping the workdir",
+            );
+            assert!(
+                result
+                    .diagnostics
+                    .iter()
+                    .any(|d| d.message.contains("escapes")),
+                "expected an escape diagnostic for `{path}`; got: {:?}",
+                result.diagnostics,
+            );
+        }
+    }
+
+    #[test]
+    fn repository_cue_rejects_writes_into_cue_mod() {
+        // A push that tries to write into `cue.mod/` would overwrite the
+        // synthetic module declaration the validator installs, letting a
+        // crafted source steer cuengine's evaluation environment. Must be
+        // refused before any filesystem write.
+        for path in ["cue.mod/module.cue", "cue.mod/pkg/foo.cue"] {
+            let result = validate_repository_cue_sources(
+                "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
+                "0123456789abcdef0123456789abcdef01234567",
+                &[CueFile {
+                    path: path.to_string(),
+                    source: "package comtrya".to_string(),
+                }],
+                &CueEvalBudget::default(),
+            )
+            .unwrap();
+            assert!(
+                !result.accepted,
+                "path `{path}` must be rejected as writing into cue.mod/",
+            );
+            assert!(
+                result
+                    .diagnostics
+                    .iter()
+                    .any(|d| d.message.contains("cue.mod/")),
+                "expected a cue.mod diagnostic for `{path}`; got: {:?}",
+                result.diagnostics,
+            );
+        }
+    }
+
+    #[test]
+    fn repository_cue_diagnostic_scrubs_workdir_path() {
+        // cuengine emits absolute tempdir paths in its error messages. The
+        // helper must scrub them — leaking host paths to GraphQL clients
+        // is an information disclosure.
+        let result = validate_repository_cue_sources(
+            "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
+            "0123456789abcdef0123456789abcdef01234567",
+            &[CueFile {
+                path: "comtrya.cue".to_string(),
+                source: "package comtrya\nfoo: \"a\"\nfoo: 42".to_string(),
+            }],
+            &CueEvalBudget::default(),
+        )
+        .unwrap();
+
+        assert!(!result.accepted);
+        let tempdir_root = std::env::temp_dir();
+        let tempdir_str = tempdir_root.to_str().unwrap_or("");
+        let joined = result
+            .diagnostics
+            .iter()
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !joined.contains(tempdir_str),
+            "diagnostic leaked tempdir path `{tempdir_str}`: {joined}",
+        );
     }
 
     #[test]

--- a/crates/core/src/git_storage.rs
+++ b/crates/core/src/git_storage.rs
@@ -453,7 +453,10 @@ mod tests {
                 Vec::new(),
                 vec![CueFile {
                     path: "comtrya.cue".to_string(),
-                    source: "package comtrya\ninvalid: true".to_string(),
+                    // Real CUE type-conflict (under the cuengine-backed
+                    // validator). Was `"invalid: true"` under the legacy
+                    // string-match stub.
+                    source: "package comtrya\nfoo: \"a\"\nfoo: 42".to_string(),
                 }],
             )
             .unwrap();

--- a/crates/core/tests/mvp_flow.rs
+++ b/crates/core/tests/mvp_flow.rs
@@ -72,7 +72,9 @@ fn kernel_mvp_flow_is_exercised_through_contract_layer() {
             Vec::new(),
             vec![CueFile {
                 path: "comtrya.cue".to_string(),
-                source: "package comtrya\ninvalid: true".to_string(),
+                // Real CUE error under the cuengine-backed validator
+                // (replaces the legacy magic-string trigger).
+                source: "package comtrya\nfoo: \"a\"\nfoo: 42".to_string(),
             }],
         )
         .unwrap();

--- a/crates/server/docs/adrs/0002-cuengine-for-repo-config.mdx
+++ b/crates/server/docs/adrs/0002-cuengine-for-repo-config.mdx
@@ -11,10 +11,13 @@ Repos describe themselves to Comtrya through a `package comtrya` CUE configurati
 
 ## Decision
 
-Use `cuengine` from crates.io (the Go-Rust FFI bridge from the cuenv project). On every repo configuration read, the kernel materialises a working tree from the bare git directory via `git archive | tar -x`, drops the kernel base schema and every extension-registered snippet into `_comtrya/`, then calls `evaluate_module(recursive: true, package_name: "comtrya")`.
+Use `cuengine` from crates.io (the Go-Rust FFI bridge from the cuenv project). On every repo configuration read, the kernel materialises a working tree from the bare git directory via `git archive | tar -x`, drops the kernel base schema and every extension-registered snippet at the workdir root as `00-comtrya-kernel.cue` and `01-comtrya-ext-<id>-<schema>.cue` (name-prefixed for stable ordering), then calls `evaluate_module(recursive: true, package_name: "comtrya")`. The same crate is also used by the receive-pack validator (`comtrya-core::config::evaluate_cue_files_with_cuengine`) to reject semantically broken `package comtrya` pushes at write time.
+
+> NOTE — an earlier revision of this ADR proposed `_comtrya/` as the schema injection target. That was abandoned because CUE's loader silently skips `_`-prefixed directories during recursive `./...` evaluation (Go-module convention), which made the schemas invisible to the per-Project CUE files. Schemas are now written at the workdir ROOT with name prefixes. The validator uses the same root-level convention. Both paths also override `tempfile::Builder::new().prefix("comtrya-cue-")` for the workdir name itself — `tempfile`'s default `.tmpXXXX` prefix triggers the same loader skip.
 
 ## Consequences
 
 - Real CUE semantics — unification, references, defaults, constraints — without re-implementing CUE in Rust.
 - Adds a Go runtime dependency through the FFI bridge.
 - Per-request materialise + evaluate cost; cache by ref OID once the access pattern is clear.
+- Two cuengine call sites must stay aligned on workdir layout (synthetic `cue.mod/module.cue` content, tempdir prefix, schema injection location). A shared helper crate is a follow-up.

--- a/crates/server/src/cue_config.rs
+++ b/crates/server/src/cue_config.rs
@@ -12,7 +12,10 @@
 //!
 //! 1. Materialise the repo's working tree from the bare Git directory.
 //! 2. Drop the kernel base schema and every extension-registered snippet
-//!    into `_comtrya/` inside the workdir.
+//!    at the workdir root as name-prefixed files (`00-comtrya-kernel.cue`,
+//!    `01-comtrya-ext-<id>-<schema>.cue`) — NOT into `_comtrya/`, because
+//!    CUE's loader silently skips `_`-prefixed directories during recursive
+//!    `./...` evaluation (see ADR 0002 for the full reasoning).
 //! 3. Run `cuengine::evaluate_module(recursive: true,
 //!    package_name: "comtrya")` — the repo's `package comtrya` files
 //!    unify with the injected schemas.
@@ -277,12 +280,8 @@ fn materialise_worktree(git_dir: &Path, ref_name: &str) -> Result<PathBuf, Strin
         .duration_since(UNIX_EPOCH)
         .map(|d| d.subsec_nanos())
         .unwrap_or(0);
-    let base = std::env::temp_dir().join(format!(
-        "comtrya-cue-{}-{nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&base)
-        .map_err(|e| format!("mkdir {} failed: {e}", base.display()))?;
+    let base = std::env::temp_dir().join(format!("comtrya-cue-{}-{nanos}", std::process::id()));
+    std::fs::create_dir_all(&base).map_err(|e| format!("mkdir {} failed: {e}", base.display()))?;
 
     let archive = Command::new("git")
         .arg("--git-dir")
@@ -294,7 +293,9 @@ fn materialise_worktree(git_dir: &Path, ref_name: &str) -> Result<PathBuf, Strin
         .spawn()
         .map_err(|e| format!("git archive spawn failed: {e}"))?;
 
-    let archive_out = archive.stdout.ok_or_else(|| "git archive stdout missing".to_string())?;
+    let archive_out = archive
+        .stdout
+        .ok_or_else(|| "git archive stdout missing".to_string())?;
     let status = Command::new("tar")
         .arg("-x")
         .arg("-C")
@@ -314,8 +315,7 @@ fn install_schemas(workdir: &Path, extension_schemas: &[ExtensionSchema]) -> Res
     let module_path = workdir.join("cue.mod").join("module.cue");
     if !module_path.is_file() {
         if let Some(parent) = module_path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("mkdir cue.mod failed: {e}"))?;
+            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir cue.mod failed: {e}"))?;
         }
         std::fs::write(
             &module_path,
@@ -339,11 +339,8 @@ fn install_schemas(workdir: &Path, extension_schemas: &[ExtensionSchema]) -> Res
     // `01-comtrya-ext-<id>-<schema>.cue`) so they don't collide with
     // any user-authored CUE at the workdir root and to keep ordering
     // stable in `cue export` output.
-    std::fs::write(
-        workdir.join("00-comtrya-kernel.cue"),
-        KERNEL_CUE_BASE,
-    )
-    .map_err(|e| format!("write kernel base schema failed: {e}"))?;
+    std::fs::write(workdir.join("00-comtrya-kernel.cue"), KERNEL_CUE_BASE)
+        .map_err(|e| format!("write kernel base schema failed: {e}"))?;
 
     for schema in extension_schemas {
         let safe_id = schema.schema_id.replace(['/', ' '], "-");
@@ -406,8 +403,8 @@ fn run_cuengine(workdir: &Path) -> Value {
             // match). In both cases the user sees the same outcome we
             // produce on a successful empty evaluation: one implicit
             // Project. Don't surface the noisy library text.
-            let benign = message.contains("matched no packages")
-                || message.contains("no CUE files");
+            let benign =
+                message.contains("matched no packages") || message.contains("no CUE files");
             json!({
                 "projects": [implicit_default_project()],
                 "repository": Value::Null,
@@ -436,7 +433,10 @@ fn discover_projects(instances: &[Value]) -> Vec<Value> {
             .unwrap_or("")
             .to_string();
         let value = instance.get("value");
-        let Some(map) = value.and_then(|v| v.get("projects")).and_then(Value::as_object) else {
+        let Some(map) = value
+            .and_then(|v| v.get("projects"))
+            .and_then(Value::as_object)
+        else {
             continue;
         };
         for (name, def) in map.iter() {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -892,11 +892,7 @@ impl Runtime {
         format!("comtrya://user-layout/{principal_uri}/{repository_id}")
     }
 
-    fn get_user_layout(
-        &self,
-        principal_uri: &str,
-        repository_id: &str,
-    ) -> Result<Value, String> {
+    fn get_user_layout(&self, principal_uri: &str, repository_id: &str) -> Result<Value, String> {
         let doc_id = Self::user_layout_document_id(principal_uri, repository_id);
         let collection = self.extension_storage.collection_data("user_layouts")?;
         let entries = collection
@@ -3460,7 +3456,10 @@ fn apply_repository_cue_overrides(
         return;
     };
     if let Some(visibility) = repo_block.get("visibility").and_then(Value::as_str) {
-        repo_obj.insert("visibility".to_string(), json!(visibility.to_ascii_uppercase()));
+        repo_obj.insert(
+            "visibility".to_string(),
+            json!(visibility.to_ascii_uppercase()),
+        );
     }
     if let Some(branch) = repo_block.get("defaultBranch").and_then(Value::as_str) {
         repo_obj.insert("defaultBranch".to_string(), json!(branch));
@@ -3528,10 +3527,7 @@ fn annotate_bookmarks_with_resolution(
     repo_obj: &mut serde_json::Map<String, Value>,
     git_dir: &Path,
 ) {
-    let Some(bookmarks) = repo_obj
-        .get_mut("bookmarks")
-        .and_then(Value::as_array_mut)
-    else {
+    let Some(bookmarks) = repo_obj.get_mut("bookmarks").and_then(Value::as_array_mut) else {
         return;
     };
     for bookmark in bookmarks.iter_mut() {
@@ -3849,8 +3845,7 @@ fn git_demo_snapshot(
         &["diff", "--patch", "--find-renames", "main~1", "main"],
     )
     .unwrap_or_default();
-    let comtrya_config =
-        cue_config::evaluate_repo_config(&repo.git_dir, "main", extension_schemas);
+    let comtrya_config = cue_config::evaluate_repo_config(&repo.git_dir, "main", extension_schemas);
     let mut repository = json!({
         "id": "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
         "owner": "comtrya",
@@ -4150,8 +4145,21 @@ fn is_text_preview_path(path: &str) -> bool {
         Path::new(path)
             .extension()
             .and_then(|extension| extension.to_str()),
-        Some("md" | "mdx" | "rs" | "ts" | "tsx" | "js" | "jsx" | "vue"
-            | "json" | "toml" | "cue" | "yaml" | "yml" | "txt")
+        Some(
+            "md" | "mdx"
+                | "rs"
+                | "ts"
+                | "tsx"
+                | "js"
+                | "jsx"
+                | "vue"
+                | "json"
+                | "toml"
+                | "cue"
+                | "yaml"
+                | "yml"
+                | "txt"
+        )
     )
 }
 
@@ -8237,7 +8245,10 @@ extensions: {
             "contributes": { "slots": ["bogus"], "routes": false }
         });
         let result = validate_ui_manifest_from_value(&v2);
-        assert!(result.is_ok(), "legacy contributes block must not fail validation: {result:?}");
+        assert!(
+            result.is_ok(),
+            "legacy contributes block must not fail validation: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #7 (partial — schema-driven required-field enforcement is the one named acceptance criterion that this PR does NOT meet; tracked separately as **#18** which lists this PR as a dependency).

## Summary

Replace the literal-string `"invalid: true"` / `"!!"` stub in `validate_repository_cue_sources` with real CUE evaluation via the in-process `cuengine = "0.40"` crate. Any semantically broken `package comtrya` push (type conflict, constraint violation, parse error) now gets `accepted: false` with a real diagnostic. Path-traversal-safe (sanitizes `CueFile::path` before any filesystem write). Workdir paths are scrubbed from cuengine error messages — including the macOS canonical form (`/private/var/folders/...`) — so host filesystem layout doesn't leak to GraphQL clients.

The issue body proposed shelling out to `cue vet`. The plan switched to in-process `cuengine` because the server crate already uses it (`crates/server/src/cue_config.rs:run_cuengine`) — strictly better: no subprocess, no CLI dependency, no concurrent-subprocess pressure.

## Acceptance criteria

- [x] `validate_repository_cue_sources` runs real CUE evaluation, not a string match.
- [x] Tests cover ≥3 real CUE failure modes: conflicting values (type unification), constraint violation, parse error.
- [x] Path-traversal defense: paths with `..` components or absolute paths are rejected before any tempdir write.
- [x] Workdir paths are scrubbed from returned diagnostics (raw + canonicalized).
- [x] `cargo clippy --workspace -- -D warnings` clean; no `#[allow(...)]` added.
- [x] `cargo fmt --check` clean.
- [x] `grep '"invalid: true"' crates/core/src/config.rs` returns ZERO production-code hits (only test/comment references remain).
- [ ] **Not met — tracked in #18**: "wrong type for a *required* field" from the issue body. This requires loading the kernel `KERNEL_CUE_BASE` + extension schemas into the validator workdir. Schemas live in `crates/server` and are not yet plumbed into `crates/core`. **#18** (filed before this PR opens) carries the schema-enforcement work and lists this PR as a dependency.

## How it works

New helper `evaluate_cue_files_with_cuengine` in `crates/core/src/config.rs`:

1. **Sanitize every `CueFile::path` first** — reject absolute paths or any `Component::ParentDir` before creating a tempdir. Without this, a crafted push could write to arbitrary host paths via `tempdir.join("../../etc/...")`.
2. Create a tempdir with explicit prefix `comtrya-cue-`. **Critical**: `tempfile::TempDir`'s default `.tmpXXXX` prefix triggers Go's CUE loader to silently skip the dir as "hidden" — recursive `./...` then returns "matched no packages" even when the files are present. Discovered empirically during Stage 2.
3. Write a synthetic `cue.mod/module.cue` matching the server's `install_schemas` shape exactly (`module: "comtrya.synthesised/repo"`, `language: version: "v0.10.0"`).
4. Write each sanitized user file at its relative path under the tempdir.
5. Call `cuengine::evaluate_module(workdir, "comtrya", Some(&options))` with `recursive: true, package_name: Some("comtrya"), target_dir: None`.
6. On error: scrub both `workdir.to_str()` AND `std::fs::canonicalize(workdir).to_str()` from the message (covers macOS `/var/folders/` ↔ `/private/var/folders/` symlink), then return as a `ConfigDiagnostic`.

The "matched no packages" / "no CUE files" benign-error filter mirrors `crates/server/src/cue_config.rs:409-410` so subdirectories that legitimately contain no `package comtrya` files don't get treated as validation failures.

## Test Plan

In `crates/core/src/config.rs` test module:

- [x] `repository_cue_conflicting_values_rejected` — `foo: "a"\nfoo: 42` → real CUE type-unification rejection.
- [x] `repository_cue_constraint_violation_rejected` — `count: int & <3\ncount: 5` → constraint-solver rejection.
- [x] `repository_cue_invalid_syntax_rejected` — `foo: [` (unclosed bracket) → cuengine parse error.
- [x] `repository_cue_unbalanced_braces_caught_by_smoke_check` — `foo: {` (unclosed brace) → caught by the fast-fail `balanced_braces` walker before cuengine.
- [x] `repository_cue_path_traversal_rejected` — `["../../etc/passwd", "/etc/passwd", "a/../../etc/passwd"]` all rejected with the escape diagnostic.
- [x] `repository_cue_rejects_writes_into_cue_mod` — `["cue.mod/module.cue", "cue.mod/pkg/foo.cue"]` all rejected. A push that targets `cue.mod/` would overwrite the synthetic module declaration and steer cuengine's evaluation environment; guarded explicitly.
- [x] `repository_cue_diagnostic_scrubs_workdir_path` — confirms `std::env::temp_dir().to_str()` does NOT appear in returned diagnostic messages.

Preserved existing tests:
- [x] `repository_cue_bootstrap_without_comtrya_package_is_trivially_accepted` — no `package comtrya` files → trivially accepted.
- [x] `repository_cue_budget_breach_returns_config_invalid` — `enforce_cue_budget` still runs before cuengine.
- [x] `valid_nested_repository_cue_produces_effective_snapshots` — multi-dir CUE evaluates and snapshots both `/` and `/services/api`. With `recursive: true` and the non-dot tempdir prefix, this test genuinely exercises subdir evaluation (not the wrong-reason pass from earlier development).

Coupled test updates (both depended on the old magic-string trigger):
- [x] `crates/core/src/git_storage.rs:invalid_cue_on_default_ref_rejects_receive_pack` — source replaced with `foo: "a"\nfoo: 42`.
- [x] `crates/core/tests/mvp_flow.rs` invalid_txn block — same.

Run:
```
cargo test --package comtrya-core
# 129 passed; 0 failed (local; CI will re-verify on push)
cargo clippy --workspace -- -D warnings
cargo fmt --check
```

## Honest disclosures

1. **"Wrong type for a *required* field" not met** (issue body acceptance criterion). The validator runs cuengine over user CUE without injecting `KERNEL_CUE_BASE` or extension schemas, so kernel-declared `required` field violations aren't caught here. In-file unification and constraint violations ARE caught — which is the entire delta between the old stub and this PR. Schema injection requires moving `KERNEL_CUE_BASE` out of `crates/server` or duplicating it. **Filed as #18 before this PR opens.** That issue lists this PR as a dependency and carries the schema-enforcement work end-to-end.

2. **`CueEvalBudget::wall_time_ms` and `memory_bytes` removed** — both pre-existed as `pub` fields but were never enforced anywhere (verified by grep). The new validator puts cuengine on the receive-pack hot path, making the dead "we have a time cap" claim more misleading. Removed per CLAUDE.md "no dead code." Adding a real wall-time cap around cuengine requires thread-spawn + cancellation around the FFI call; tracked as a follow-up.

3. **`recursive: true` requires the non-dot tempdir prefix**. The Go CUE loader's "skip `.`-prefixed dirs" convention applies to the workdir itself, not just children. Documented inline in `evaluate_cue_files_with_cuengine` and in the ADR update.

4. **ADR `0002-cuengine-for-repo-config.mdx` updated, and the matching stale doc comment in `crates/server/src/cue_config.rs:14-15` updated alongside.** Both said schemas inject to `_comtrya/` but the server code drifted to root-level prefixed files in earlier commits. Updated both to match reality and to note the tempdir-prefix gotcha. The drift pre-dates this PR; bundled here because the new validator also relies on the same convention.

5. **Incidental `cargo fmt` reflow of `crates/server/src/cue_config.rs` and `crates/server/src/main.rs`** (~70 lines, whitespace only). Same pre-existing fmt drift as PR #17. Bundled so `cargo fmt --check` passes in CI.

6. **No browser verification needed**. Server-only change; no Vue/TS/asset files in the diff.

## Process trail

- Stage 1 (planning): 2 rounds. R1 caught a CRITICAL test-coupling problem (`git_storage.rs` and `mvp_flow.rs` tests also depended on the magic string), plus 7 other findings (compile bug, path traversal, macOS scrub, schema gap, etc.). R2: both SHIP.
- Stage 2 (implementation): 3 rounds. R1 caught module-version mismatch, `recursive: false` regression, canonical-path leak, dead-field cleanup. R2 caught a stale ADR. R3: SHIP.
- Stage 3 (final review): 3 reviewers (acceptance / regressions / PR honesty) pending at PR open.
