### PR TITLE
feat(ci): add github actions workflow for rust + frontend + extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,149 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel stale runs when a new commit lands on the same ref. Force-pushes
+# to main get the same treatment — they shouldn't happen anyway.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege: every job only reads the repo. No write or secrets
+# access needed for build/test/lint. None of the run: steps consume
+# untrusted external inputs (issue titles, PR bodies, commit messages,
+# etc.) — the only template expansion inside run: is `matrix.extension`,
+# which is derived from `ls extensions/first-party` (a filesystem glob).
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: cargo fmt + clippy + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Rust 2024 edition requires Rust 1.85+ (released 2025-02-20).
+      # Pinning to `stable` follows the channel and avoids stale-pin breakage.
+      # Host workspace excludes extensions/first-party/*/component, so no
+      # wasm32 target is installed here — the extension-build job below
+      # installs it where it's actually used.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      # cuengine 0.40.6 (transitive dep of crates/server and crates/core)
+      # has a build.rs that shells out to `go build` to compile its FFI
+      # bridge. cuengine's go.mod declares `go 1.25.0` as the MINIMUM;
+      # tracking `stable` (currently 1.26.x) satisfies that and matches
+      # the rust-toolchain philosophy of following the channel.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      # Caches ~/.cargo/{registry,git} and target/ keyed on Cargo.lock.
+      # cuengine's Go FFI artifacts live under target/debug/build/cuengine-*/
+      # and ride along automatically.
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy -D warnings
+        run: cargo clippy --workspace -- -D warnings
+
+      # NOTE: 18 tests on v3 HEAD are known-broken until PR #17 lands its
+      # precondition fix. See PR description for the full inventory; do
+      # NOT enable required-checks on this job until #17 is merged.
+      - name: cargo test --workspace
+        run: cargo test --workspace
+
+  frontend:
+    name: bun typecheck + test + build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Bun Hard Rule (AGENTS.md): never npm/yarn/pnpm.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: bun install
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: bun run typecheck
+        working-directory: frontend
+        run: bun run typecheck
+
+      - name: bun test
+        working-directory: frontend
+        run: bun test
+
+      - name: bun run build
+        working-directory: frontend
+        run: bun run build
+
+  # Glob-derived matrix so a 7th first-party extension is picked up
+  # automatically. Avoids hardcoded first-party names per AGENTS.md's
+  # "no first-party special cases" rule (spirit of the rule applied
+  # to CI configuration).
+  extensions-matrix:
+    name: discover first-party extensions
+    runs-on: ubuntu-latest
+    outputs:
+      extensions: ${{ steps.list.outputs.extensions }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: list
+        # Filter to directories only — a stray file in extensions/first-party/
+        # (e.g. a future .gitkeep or README.md) would otherwise become a
+        # matrix cell and fail the bundler's `[[ ! -d "$root" ]]` guard.
+        run: |
+          names=$(find extensions/first-party -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | jq -R . | jq -sc .)
+          echo "extensions=$names" >> "$GITHUB_OUTPUT"
+
+  extension-build:
+    name: bundle ${{ matrix.extension }}
+    needs: [extensions-matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extension: ${{ fromJSON(needs.extensions-matrix.outputs.extensions) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: Swatinem/rust-cache@v2
+
+      # cargo-component drives `cargo component build` for each WASM
+      # Component-Model extension. Pin to the exact released patch.
+      - name: install cargo-component
+        run: cargo install --locked cargo-component --version 0.21.1
+
+      # Every extension's ui/vite.config.ts imports via relative paths
+      # into `../../../../frontend/node_modules/...`. Without populating
+      # frontend/ first, the bundler's `bun run build` step inside each
+      # ui/ directory fails with module-not-found.
+      - name: bun install (frontend workspace, shared by extension UIs)
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      # `matrix.extension` is glob-derived from `ls extensions/first-party`
+      # (see extensions-matrix job). Not untrusted external input.
+      - name: build extension
+        env:
+          EXTENSION: ${{ matrix.extension }}
+        run: extensions/bundler/build-extension.sh "extensions/first-party/$EXTENSION"


### PR DESCRIPTION
Addresses #10 (partial — the branch-protection / required-checks step is a manual repo-admin action that cannot be automated from a workflow file; see "Acceptance criteria" and "Merge ordering" below). Use `Closes #10` only after an admin has enabled required checks on the `main` branch-protection page **and** the test suite is green on `main` (PR #17 lands first).

## Summary

Adds `.github/workflows/ci.yml` — a single GitHub Actions workflow that runs every CLAUDE.md-mandated check on every PR and every push to `main`. Four jobs across three logical stages: `rust` (fmt + clippy + test), `frontend` (Bun typecheck + test + build), and a two-step extension pipeline (`extensions-matrix` discovers first-party extensions by glob → `extension-build` invokes the bundler per cell with `fail-fast: false`).

## Acceptance criteria

- [x] `ci.yml` triggered on `pull_request` and `push: branches: [main]`.
- [x] Rust job: `stable` toolchain (≥1.85 for edition 2024) + Go `stable` channel (≥1.25 for cuengine FFI), `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`.
- [x] Frontend job: `bun install --frozen-lockfile`, `bun run typecheck`, `bun test`, `bun run build`. No npm/yarn/pnpm anywhere (Bun Hard Rule).
- [x] Extension build matrix: each first-party extension built via `extensions/bundler/build-extension.sh`. Matrix derived from `find extensions/first-party -mindepth 1 -maxdepth 1 -type d` so a 7th extension is picked up automatically — no hardcoded first-party names.
- [x] (Optional but recommended) cache `~/.cargo/{registry,git}`, `target/` via `Swatinem/rust-cache@v2`. Bun has its own internal cache (no extra step here; tuning is a follow-up).
- [ ] **Human step (NOT automated; #10 stays open until this is done)**: mark these jobs as required checks on the `main` branch-protection page. **Do NOT enable required-checks until PR #17 has merged** — see "Merge ordering" below. Once the admin has enabled them, close #10 manually with a confirmation comment ("required checks live: rust, frontend, extension-build").

## How it works

Four jobs (the last two form a single logical extension-build stage with a `needs:` dependency) running on `ubuntu-latest`:

1. **`rust`** — `dtolnay/rust-toolchain@stable` (rustfmt + clippy components) + `actions/setup-go@v5` for `cuengine`'s FFI build + `Swatinem/rust-cache@v2`. No `wasm32-unknown-unknown` target here — the host workspace excludes `extensions/first-party/*/component`.

2. **`frontend`** — `oven-sh/setup-bun@v2` then install + typecheck + test + build, all `working-directory: frontend`.

3. **`extensions-matrix` → `extension-build`** — first job emits `ls`-equivalent JSON via `find ... -type d -printf '%f\n' | jq -R . | jq -sc .`; second job consumes via `fromJSON(needs.extensions-matrix.outputs.extensions)` with `fail-fast: false`. Per cell: Rust + Bun + `cargo install --locked cargo-component --version 0.21.1` + `cd frontend && bun install --frozen-lockfile` (needed because every extension's `ui/vite.config.ts` imports via relative paths into `../../../../frontend/node_modules/...`) + run the bundler.

Workflow-level `permissions: contents: read` (least-privilege) and `concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }` (stale runs canceled on new commits to the same ref).

## Merge ordering (READ BEFORE MERGING)

The workspace test suite on v3 HEAD has **18 known-failing tests** — the precondition compile-error fix is in **PR #17**, which must merge first so this workflow has a green baseline.

**Preferred merge order:**
1. **PR #17** first (precondition fix that unblocks workspace test compilation; tracks PR-#17's own merge gate).
2. **This PR (#10)** second. First main-branch CI run is then expected to be green-or-explicable.
3. **PR #19** third (its tests will be validated by the now-live CI).

**Fallback** (if PR #17 isn't ready): merge this PR as **infrastructure-only**. The workflow file lives on `main` but the repo admin does **NOT** enable required-checks on the branch-protection rules until #17 also lands. PR-author noise from red CI is acceptable for a few days; permanent required-check breakage is not.

Either way, **required checks are a manual repo-admin step** — this PR does not (and cannot, without admin tokens) configure branch protection.

## Test Plan

**Implementer note:** stage ONLY `.github/workflows/ci.yml` (`git add .github/workflows/ci.yml`). `PLAN_P1-11.md` and `PR_BODY.md` are loop meta-artifacts that live in the worktree and must not enter the repo's commit history. Don't `git add .` / `git add -A` carelessly.

There are no traditional unit tests for a CI workflow file — the CI is its own test, validated on the first push. Validation loop:

- [x] YAML written per the plan; structure verified by both stage-2 reviewers.
- [x] No `npm`/`yarn`/`pnpm` anywhere in the file (`grep -E 'npm|yarn|pnpm' .github/workflows/ci.yml` returns only the comment that names the Bun Hard Rule).
- [x] No hardcoded extension names (`grep -E 'ext_(issues|epics|checks|docs|pull_requests|workspace_home)' .github/workflows/ci.yml` returns 0).
- [x] No untrusted external input in any `run:` block. Only template expansion in any `run:` is `${{ matrix.extension }}`, passed via env var with quoted shell expansion. No `github.event.*` / `github.head_ref` / commit-message expansion anywhere.
- [ ] **First CI run on push** — will validate YAML syntax, action resolution, and step ordering. Expected outcome:
  - `rust` job: red (`cargo test --workspace` hits the 18 pre-existing failures until PR #17 lands).
  - `frontend` job: green (no known breakage).
  - `extensions-matrix` + `extension-build` matrix: green if extensions build on HEAD; matrix surfaces per-extension failures with `fail-fast: false`.

## Honest disclosures

1. **First CI run will be red** on the `rust` job until PR #17 merges. This is documented in the workflow file inline (comment at the `cargo test --workspace` step) and in the merge-ordering section above. Not a bug — a documented prerequisite.

2. **Browser smoke (Chrome MCP) is deliberately OUT OF SCOPE for CI.** CLAUDE.md's UI Verification Hard Rule applies to developer/agent commits, not to CI. CI builds and typechecks the frontend; browser exercise remains a pre-commit obligation.

3. **`./start.sh --reset --oneshot` is deliberately excluded.** It requires a full running stack (data dirs, backgrounded server, backgrounded frontend, HTTP polling) — materially different from build/test gates. Tracked as a follow-up alongside container builds (#12).

4. **Third-party actions pinned to floating tags** (`@v4`, `@v5`, `@v2`) rather than SHA. Public repo, no secrets exposed, all actions used are from trusted publishers. SHA pinning + Dependabot is a follow-up if OpenSSF Scorecard is adopted.

5. **`cargo install --locked cargo-component --version 0.21.1` runs in every matrix cell.** ~3 min × 6 cells = ~18 min wasted on cargo-component compilation per CI run. Documented in the plan as acceptable for first-pass; tuning is a follow-up.

6. **No `Cargo.audit` / `cargo-deny` step.** Not in scope per plan; worth a follow-up issue.

## Process trail

- Stage 1 (planning): 2 review rounds. Round 1 caught Rust 1.84 doesn't support edition 2024, bun install missing in extension Job 3, hardcoded matrix violates spirit of "no first-party special cases," perma-red CI undermines signal. Round 2 SHIP.
- Stage 2 (YAML implementation): 2 review rounds. Round 1 reviewer #1 SHIP; reviewer #2 REVISE on dead `wasm32-unknown-unknown` target + `ls -1` should filter directories. Round 2 SHIP.
- Stage 3 (final review): 3 reviewers (acceptance / regressions / PR honesty) pending at PR open.
