### PR TITLE
fix(server): remove ext_01hv legacy alias (#6 P1-7)

### DIFF
--- a/crates/core/src/frontend_contracts.rs
+++ b/crates/core/src/frontend_contracts.rs
@@ -142,9 +142,9 @@ mod tests {
             schema_version: "comtrya.ui-extension/v1".to_string(),
             extension: "pull-requests".to_string(),
             assets: UiAssets {
-                entry: "/_extensions/ext_01hv/assets/index.js".to_string(),
+                entry: "/_extensions/ext_pull_requests/assets/index.js".to_string(),
                 entry_integrity: Some(stable_integrity(b"console.log(1)")),
-                styles: vec!["/_extensions/ext_01hv/assets/styles.css".to_string()],
+                styles: vec!["/_extensions/ext_pull_requests/assets/styles.css".to_string()],
             },
             routes: vec![UiRoute {
                 path: "/:workspace/:repo/pulls".to_string(),
@@ -167,7 +167,7 @@ mod tests {
         let response = extension_asset_response(
             "http://localhost:4321",
             &["http://localhost:4321".to_string()],
-            "/_extensions/ext_01hv/assets/index.abc123.js",
+            "/_extensions/ext_pull_requests/assets/index.abc123.js",
             b"console.log(1)",
             "text/javascript",
             true,
@@ -195,7 +195,7 @@ mod tests {
             extension_asset_response(
                 "https://evil.example",
                 &["http://localhost:4321".to_string()],
-                "/_extensions/ext_01hv/assets/index.js",
+                "/_extensions/ext_pull_requests/assets/index.js",
                 b"",
                 "text/javascript",
                 false,

--- a/crates/core/tests/mvp_flow.rs
+++ b/crates/core/tests/mvp_flow.rs
@@ -149,7 +149,7 @@ fn kernel_mvp_flow_is_exercised_through_contract_layer() {
     let asset = extension_asset_response(
         "http://localhost:4321",
         &["http://localhost:4321".to_string()],
-        "/_extensions/ext_01hv/assets/index.abc123.js",
+        "/_extensions/ext_pull_requests/assets/index.abc123.js",
         b"customElements.define('x-test', class extends HTMLElement {})",
         "text/javascript",
         true,

--- a/crates/server/src/cue_config.rs
+++ b/crates/server/src/cue_config.rs
@@ -277,12 +277,8 @@ fn materialise_worktree(git_dir: &Path, ref_name: &str) -> Result<PathBuf, Strin
         .duration_since(UNIX_EPOCH)
         .map(|d| d.subsec_nanos())
         .unwrap_or(0);
-    let base = std::env::temp_dir().join(format!(
-        "comtrya-cue-{}-{nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&base)
-        .map_err(|e| format!("mkdir {} failed: {e}", base.display()))?;
+    let base = std::env::temp_dir().join(format!("comtrya-cue-{}-{nanos}", std::process::id()));
+    std::fs::create_dir_all(&base).map_err(|e| format!("mkdir {} failed: {e}", base.display()))?;
 
     let archive = Command::new("git")
         .arg("--git-dir")
@@ -294,7 +290,9 @@ fn materialise_worktree(git_dir: &Path, ref_name: &str) -> Result<PathBuf, Strin
         .spawn()
         .map_err(|e| format!("git archive spawn failed: {e}"))?;
 
-    let archive_out = archive.stdout.ok_or_else(|| "git archive stdout missing".to_string())?;
+    let archive_out = archive
+        .stdout
+        .ok_or_else(|| "git archive stdout missing".to_string())?;
     let status = Command::new("tar")
         .arg("-x")
         .arg("-C")
@@ -314,8 +312,7 @@ fn install_schemas(workdir: &Path, extension_schemas: &[ExtensionSchema]) -> Res
     let module_path = workdir.join("cue.mod").join("module.cue");
     if !module_path.is_file() {
         if let Some(parent) = module_path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("mkdir cue.mod failed: {e}"))?;
+            std::fs::create_dir_all(parent).map_err(|e| format!("mkdir cue.mod failed: {e}"))?;
         }
         std::fs::write(
             &module_path,
@@ -339,11 +336,8 @@ fn install_schemas(workdir: &Path, extension_schemas: &[ExtensionSchema]) -> Res
     // `01-comtrya-ext-<id>-<schema>.cue`) so they don't collide with
     // any user-authored CUE at the workdir root and to keep ordering
     // stable in `cue export` output.
-    std::fs::write(
-        workdir.join("00-comtrya-kernel.cue"),
-        KERNEL_CUE_BASE,
-    )
-    .map_err(|e| format!("write kernel base schema failed: {e}"))?;
+    std::fs::write(workdir.join("00-comtrya-kernel.cue"), KERNEL_CUE_BASE)
+        .map_err(|e| format!("write kernel base schema failed: {e}"))?;
 
     for schema in extension_schemas {
         let safe_id = schema.schema_id.replace(['/', ' '], "-");
@@ -406,8 +400,8 @@ fn run_cuengine(workdir: &Path) -> Value {
             // match). In both cases the user sees the same outcome we
             // produce on a successful empty evaluation: one implicit
             // Project. Don't surface the noisy library text.
-            let benign = message.contains("matched no packages")
-                || message.contains("no CUE files");
+            let benign =
+                message.contains("matched no packages") || message.contains("no CUE files");
             json!({
                 "projects": [implicit_default_project()],
                 "repository": Value::Null,
@@ -436,7 +430,10 @@ fn discover_projects(instances: &[Value]) -> Vec<Value> {
             .unwrap_or("")
             .to_string();
         let value = instance.get("value");
-        let Some(map) = value.and_then(|v| v.get("projects")).and_then(Value::as_object) else {
+        let Some(map) = value
+            .and_then(|v| v.get("projects"))
+            .and_then(Value::as_object)
+        else {
             continue;
         };
         for (name, def) in map.iter() {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -892,11 +892,7 @@ impl Runtime {
         format!("comtrya://user-layout/{principal_uri}/{repository_id}")
     }
 
-    fn get_user_layout(
-        &self,
-        principal_uri: &str,
-        repository_id: &str,
-    ) -> Result<Value, String> {
+    fn get_user_layout(&self, principal_uri: &str, repository_id: &str) -> Result<Value, String> {
         let doc_id = Self::user_layout_document_id(principal_uri, repository_id);
         let collection = self.extension_storage.collection_data("user_layouts")?;
         let entries = collection
@@ -1182,9 +1178,6 @@ impl Runtime {
     }
 
     fn extension_runtime_record(&self, extension: &str) -> Option<&ExtensionRuntimeRecord> {
-        if extension == "ext_01hv" {
-            return self.extension_runtime_record("ext_pull_requests");
-        }
         self.extension_runtime.get(extension)
     }
 
@@ -2727,10 +2720,8 @@ async fn extension_manifest(
     AxumPath(extension): AxumPath<String>,
     headers: HeaderMap,
 ) -> Response {
-    let cors = match state
-        .runtime
-        .check_boundary(&headers, "/_extensions/ext_01hv/manifest.json")
-    {
+    let cors_route = format!("/_extensions/{extension}/manifest.json");
+    let cors = match state.runtime.check_boundary(&headers, &cors_route) {
         Ok(cors) => cors,
         Err(response) => return *response,
     };
@@ -2754,10 +2745,8 @@ async fn extension_asset(
     AxumPath((extension, asset_path)): AxumPath<(String, String)>,
     headers: HeaderMap,
 ) -> Response {
-    let cors = match state
-        .runtime
-        .check_boundary(&headers, "/_extensions/ext_01hv/assets/index.js")
-    {
+    let cors_route = format!("/_extensions/{extension}/assets/{asset_path}");
+    let cors = match state.runtime.check_boundary(&headers, &cors_route) {
         Ok(cors) => cors,
         Err(response) => return *response,
     };
@@ -3460,7 +3449,10 @@ fn apply_repository_cue_overrides(
         return;
     };
     if let Some(visibility) = repo_block.get("visibility").and_then(Value::as_str) {
-        repo_obj.insert("visibility".to_string(), json!(visibility.to_ascii_uppercase()));
+        repo_obj.insert(
+            "visibility".to_string(),
+            json!(visibility.to_ascii_uppercase()),
+        );
     }
     if let Some(branch) = repo_block.get("defaultBranch").and_then(Value::as_str) {
         repo_obj.insert("defaultBranch".to_string(), json!(branch));
@@ -3528,10 +3520,7 @@ fn annotate_bookmarks_with_resolution(
     repo_obj: &mut serde_json::Map<String, Value>,
     git_dir: &Path,
 ) {
-    let Some(bookmarks) = repo_obj
-        .get_mut("bookmarks")
-        .and_then(Value::as_array_mut)
-    else {
+    let Some(bookmarks) = repo_obj.get_mut("bookmarks").and_then(Value::as_array_mut) else {
         return;
     };
     for bookmark in bookmarks.iter_mut() {
@@ -3849,8 +3838,7 @@ fn git_demo_snapshot(
         &["diff", "--patch", "--find-renames", "main~1", "main"],
     )
     .unwrap_or_default();
-    let comtrya_config =
-        cue_config::evaluate_repo_config(&repo.git_dir, "main", extension_schemas);
+    let comtrya_config = cue_config::evaluate_repo_config(&repo.git_dir, "main", extension_schemas);
     let mut repository = json!({
         "id": "repo_01HV0K4XAVE2H6R5M8KJZ8Q1A3",
         "owner": "comtrya",
@@ -4150,8 +4138,21 @@ fn is_text_preview_path(path: &str) -> bool {
         Path::new(path)
             .extension()
             .and_then(|extension| extension.to_str()),
-        Some("md" | "mdx" | "rs" | "ts" | "tsx" | "js" | "jsx" | "vue"
-            | "json" | "toml" | "cue" | "yaml" | "yml" | "txt")
+        Some(
+            "md" | "mdx"
+                | "rs"
+                | "ts"
+                | "tsx"
+                | "js"
+                | "jsx"
+                | "vue"
+                | "json"
+                | "toml"
+                | "cue"
+                | "yaml"
+                | "yml"
+                | "txt"
+        )
     )
 }
 
@@ -8237,7 +8238,10 @@ extensions: {
             "contributes": { "slots": ["bogus"], "routes": false }
         });
         let result = validate_ui_manifest_from_value(&v2);
-        assert!(result.is_ok(), "legacy contributes block must not fail validation: {result:?}");
+        assert!(
+            result.is_ok(),
+            "legacy contributes block must not fail validation: {result:?}"
+        );
     }
 
     #[test]
@@ -8643,6 +8647,7 @@ extensions: {
                 root: PathBuf::new(),
                 ui_manifest: PathBuf::new(),
                 route_prefix: Some("pulls".to_string()),
+                cue_schemas: Vec::new(),
             },
         );
         let result = inject_route_prefix(extensions, &configs, &runtime);

--- a/crates/server/src/wasm_host.rs
+++ b/crates/server/src/wasm_host.rs
@@ -1989,6 +1989,10 @@ mod m1_ext_issues_smoke {
             repository: "comtrya://workspace/ws_test/repository/repo_test".into(),
             title: "M1 smoke".into(),
             body_markdown: "test body".into(),
+            project_name: None,
+            labels: vec![],
+            close_on_merge: None,
+            assignees: vec![],
         };
         let opened = issues
             .comtrya_ext_issues_issues()

--- a/extensions/examples/pull-requests/ui/manifest.json
+++ b/extensions/examples/pull-requests/ui/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": "comtrya.ui-extension/v1",
   "extension": "pull-requests",
   "assets": {
-    "entry": "/_extensions/ext_01hv/assets/index.js",
+    "entry": "/_extensions/pull-requests/assets/index.js",
     "entryIntegrity": "sha256-development",
-    "styles": ["/_extensions/ext_01hv/assets/styles.css"]
+    "styles": ["/_extensions/pull-requests/assets/styles.css"]
   },
   "routes": [
     {


### PR DESCRIPTION
Addresses #6 (P1-7 only — the other six sub-tasks ship in separate PRs per the issue body's "PRs may split" note). After this lands, mark P1-7 checked on issue #6 but leave the issue open until the remaining sub-tasks are also done.

## Summary

Deletes the `ext_01hv → ext_pull_requests` legacy alias and every remaining reference to the old extension ID. `grep -rn ext_01hv .` across all source extensions returns ZERO after this PR.

The alias was a textbook back-compat shim of exactly the kind CLAUDE.md prohibits ("Do not add backwards compatibility layers, migration shims, compatibility aliases"). It also violated the "Keep codegen generic; it must not know about a specific first-party extension" rule.

## Acceptance criteria (subset of #6)

- [x] **P1-7 — Remove `ext_01hv` legacy alias.** All 10 hits across 4 source files + 1 example-manifest doc file deleted. Grep returns 0 across `*.rs`, `*.ts`, `*.json`, `*.toml`, `*.cue`, `*.sh`, `*.html`, `*.js`, `*.yml`, `*.yaml`.
- [ ] P0-5, P0-6, P1-8, P1-9, P1-10, P1-12 — separate PRs per issue body's allowance.

## What changed

| File | Change |
|---|---|
| `crates/server/src/main.rs:1185` | Delete `if extension == "ext_01hv" { return self.extension_runtime_record("ext_pull_requests"); }` — the canonical first-party special case in generic kernel dispatch. Function becomes a single line: `self.extension_runtime.get(extension)`. |
| `crates/server/src/main.rs:~2730, ~2757` | Replace hardcoded `"/_extensions/ext_01hv/..."` CORS route placeholders with `format!("/_extensions/{extension}/...")` using the handler's own Axum-extracted path parameters. The route string only affects CORS method matching (prefix-based per `crates/core/src/http.rs:43`), so this change is behaviorally equivalent — the cleanup is for accuracy + grep-ability, not behavior. |
| `crates/core/src/frontend_contracts.rs` | 4 path-literal updates in tests (`ext_01hv` → `ext_pull_requests`). Test assertions check status / headers / error codes, not the path-string content. |
| `crates/core/tests/mvp_flow.rs:152` | 1 path-literal update — same pattern. |
| `extensions/examples/pull-requests/ui/manifest.json` | 2 asset-path updates (`ext_01hv` → `pull-requests`, bare, matching the manifest's top-level `extension: "pull-requests"` field). Confirmed unloaded by any platform code (`grep -rn extensions/examples` across `*.rs/*.toml/*.cue/*.sh` returns 0). |

## Test Plan

- [x] `grep -rn "ext_01hv" . --include="*.rs" --include="*.ts" --include="*.json" --include="*.toml" --include="*.cue" --include="*.sh" --include="*.html" --include="*.js" --include="*.yml" --include="*.yaml"` returns 0 source hits. (Only `PLAN_P1-7.md`, an uncommitted loop meta-artifact, contains the string — verified not staged.)
- [x] `cargo test --package comtrya-core` — 123 pass, 0 fail.
- [x] `cargo clippy --workspace -- -D warnings` clean.
- [x] `cargo fmt --check` clean (one incidental `cargo fmt` reflow of `crates/server/src/cue_config.rs` is bundled — same pre-existing fmt drift that PRs #17 and #19 cleaned up).
- [x] `cargo test --bin comtrya-server` — 96 pass, 18 fail. Verified by `git stash` that all 18 are pre-existing on v3 HEAD; none are newly introduced by this PR. Run completes only after the precondition fixes below are applied (else test fixtures don't compile).
- [ ] **No browser verification needed.** Server-only change; no Vue/TS/asset files modified.

## Honest disclosures

1. **Bundled precondition test-compile fix from PR #17.** The v3 baseline's test suite has the same 2 missing-field initializers (`OpenIssueInput` and `ExtensionRuntimeRecord`) that block `cargo test --bin comtrya-server` from compiling. This PR re-applies the fix (5 lines total) so the server tests can be validated against the ext_01hv removal. If PR #17 lands first, those edits become no-ops here; if this PR lands first, the precondition lives twice in history but neither is destructive. Same pattern as PR #19.

2. **Incidental `cargo fmt` reflow** of `crates/server/src/cue_config.rs` (~30 lines, whitespace only). The file wasn't fmt-clean on v3 HEAD. Bundled so `cargo fmt --check` passes in CI (per the new CI workflow in PR #20).

3. **CORS route placeholder change is cosmetic.** `allowed_methods_for_route` matches the `/_extensions/` prefix only (`crates/core/src/http.rs:43`); the embedded extension name was never load-bearing. The new `format!()` form is more accurate and makes the route string consumable for any future debugging that wants the actual path.

4. **Example manifest naming.** The example uses bare `pull-requests` (no `ext_` prefix) matching its top-level `extension` field. First-party extensions use `ext_` prefixes because that's how they're registered in the runtime; the example uses the bare form because its `extension` field declares it that way. Internally consistent.

5. **Scope discipline.** Issue #6 has 7 sub-tasks. This PR delivers only P1-7. Issue stays open after merge with the P1-7 box checked; the other six sub-tasks are independent and warrant their own PRs.

## Process trail

- Stage 1 (planning): **1 review round** — both reviewers SHIP first time. Narrow single-sub-task scope paid off vs iteration #2's sprawl abort.
- Stage 2 (implementation): **1 review round** — both reviewers SHIP first time. Path-injection check on `format!()` confirmed safe (Axum `:extension` is single-segment, doesn't decode `%2F` into the slot).
- Stage 3 (final review): 3 reviewers (acceptance / regressions / PR honesty) pending at PR open.
