### PR TITLE
feat(server): OIDC login-redirect scaffolding for #16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,9 +174,21 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -200,6 +218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -355,6 +382,7 @@ name = "comtrya-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "bytes",
  "comtrya-core",
@@ -362,6 +390,8 @@ dependencies = [
  "comtrya-wit-codegen",
  "cuengine",
  "jsonschema",
+ "openidconnect",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -378,6 +408,12 @@ dependencies = [
  "serde_json",
  "wit-parser 0.235.0",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation-sys"
@@ -561,6 +597,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +636,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,12 +711,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -617,6 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -639,10 +761,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embedded-io"
@@ -707,6 +894,22 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -868,6 +1071,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -918,7 +1122,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -1801,6 +2005,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +2023,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1860,6 +2081,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -2103,6 +2339,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2372,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2167,6 +2420,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2294,6 +2556,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -2476,6 +2741,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2815,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -2544,7 +2846,7 @@ checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -2591,6 +2893,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,6 +2980,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2999,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2684,6 +3080,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2874,6 +3279,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,6 +3383,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,10 +3407,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3047,10 +3511,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -3070,6 +3572,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -3117,6 +3629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3647,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3193,6 +3746,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,6 +3787,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3813,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -3347,6 +3932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3610,6 +4196,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3771,7 +4358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -3796,7 +4383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -3808,7 +4395,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -3820,7 +4407,7 @@ checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -3832,7 +4419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -3902,7 +4489,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "object",
  "postcard",
@@ -3965,7 +4552,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",
@@ -4066,7 +4653,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "wit-parser 0.245.1",
 ]
 
@@ -4429,7 +5016,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4460,7 +5047,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4479,7 +5066,7 @@ checksum = "0a1f95a87d03a33e259af286b857a95911eb46236a0f726cbaec1227b3dfc67a"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4497,7 +5084,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4516,7 +5103,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,3 +21,6 @@ tokio = { version = "1.52.1", features = ["macros", "net", "rt-multi-thread", "s
 wasmtime = { version = "43.0.2", default-features = false, features = ["anyhow", "component-model", "cranelift", "runtime", "std", "wat"] }
 jsonschema = { version = "0.18", default-features = false }
 cuengine = "0.40"
+openidconnect = "4.0.1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+async-trait = "0.1"

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -26,6 +26,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Semaphore;
 
 mod cue_config;
+mod oidc;
 mod wasm_host;
 mod wasm_invokers;
 mod wasm_registry;
@@ -156,6 +157,11 @@ fn router(state: AppState) -> Router {
         .route("/events", get(events))
         .route("/events/session", post(events_session))
         .route("/auth/token-exchange", post(token_exchange))
+        .route("/auth/oidc/:provider/login", get(oidc_login))
+        .route(
+            "/auth/oidc/:provider/callback",
+            get(oidc_callback_not_implemented),
+        )
         .route("/auth/oidc/*path", any(unsupported_route))
         .route("/_extensions/session", post(extension_session))
         .route(
@@ -261,6 +267,8 @@ struct Runtime {
     credentials: Mutex<HashMap<String, CredentialRecord>>,
     rate_limits: Mutex<HashMap<(String, u64), u32>>,
     token_counter: AtomicU64,
+    oidc_sessions: oidc::OidcSessionStore,
+    oidc_discovery: oidc::OidcDiscoveryCache,
 }
 
 #[derive(Debug, Clone)]
@@ -385,6 +393,8 @@ impl Runtime {
             credentials: Mutex::new(HashMap::new()),
             rate_limits: Mutex::new(HashMap::new()),
             token_counter: AtomicU64::new(0),
+            oidc_sessions: oidc::OidcSessionStore::new(),
+            oidc_discovery: oidc::OidcDiscoveryCache::with_reqwest(),
         };
         runtime
             .wasm_registry
@@ -1513,11 +1523,12 @@ struct UnsupportedSurface {
 }
 
 const UNSUPPORTED_SURFACES: &[UnsupportedSurface] = &[
-    UnsupportedSurface {
-        id: "oidc_browser_callback",
-        path_prefix: "/auth/oidc/",
-        message: "full OIDC browser callback validation is not implemented in the production-testbed runtime",
-    },
+    // OIDC login redirect now ships as a real handler at
+    // `/auth/oidc/:provider/login`. The callback at
+    // `/auth/oidc/:provider/callback` returns 501 directly from its
+    // own handler, so no `UNSUPPORTED_SURFACES` entry is needed for
+    // OIDC. The catch-all `/auth/oidc/*path` fallback handler still
+    // exists but no longer serves the login/callback paths.
     UnsupportedSurface {
         id: "git_receive_pack",
         path_prefix: "/git/",
@@ -2771,6 +2782,171 @@ async fn token_exchange(
             "expiresIn": 300,
             "scope": request.requested_actions,
             "resource": request.requested_resource
+        }),
+        cors,
+    )
+}
+
+async fn oidc_login(
+    State(state): State<AppState>,
+    AxumPath(provider): AxumPath<String>,
+    headers: HeaderMap,
+) -> Response {
+    let route = format!("/auth/oidc/{provider}/login");
+    let cors = match state.runtime.check_boundary(&headers, &route) {
+        Ok(c) => c,
+        Err(r) => return *r,
+    };
+
+    // Every error return AFTER `cors` is obtained must pass `cors` through,
+    // else cross-origin browsers see an opaque CORS failure instead of the
+    // 4xx/5xx body.
+    let err = |status: StatusCode, code: &str, msg: &str| -> Response {
+        json_response(
+            status,
+            json!({"errors": [{"message": msg, "extensions": {"code": code}}]}),
+            cors.clone(),
+        )
+    };
+
+    let issuer = match state
+        .runtime
+        .config
+        .oidc_issuers
+        .iter()
+        .find(|i| i.id == provider)
+    {
+        Some(i) => i.clone(),
+        None => {
+            return err(
+                StatusCode::NOT_FOUND,
+                ErrorCode::NotFound.as_str(),
+                &format!("unknown OIDC provider: {provider}"),
+            );
+        }
+    };
+
+    // Parse redirect URL eagerly — config validation doesn't call
+    // RedirectUrl::new, so a malformed URL would blow up inside the
+    // builder chain.
+    let redirect_uri = match openidconnect::RedirectUrl::new(issuer.redirect_url.clone()) {
+        Ok(u) => u,
+        Err(e) => {
+            return err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorCode::ConfigInvalid.as_str(),
+                &format!("invalid OIDC redirect_url in config: {e}"),
+            );
+        }
+    };
+
+    let metadata = match state
+        .runtime
+        .oidc_discovery
+        .get_or_fetch(&issuer.id, &issuer.issuer_url)
+        .await
+    {
+        Ok(m) => m,
+        Err(e) => {
+            // Discovery endpoint unreachable / returned non-JSON / etc.
+            // `StorageUnavailable` is the closest existing `ErrorCode` —
+            // semantically "an upstream we depend on isn't responding."
+            return err(
+                StatusCode::BAD_GATEWAY,
+                ErrorCode::StorageUnavailable.as_str(),
+                &format!("OIDC discovery failed: {e}"),
+            );
+        }
+    };
+
+    let client = openidconnect::core::CoreClient::from_provider_metadata(
+        metadata,
+        openidconnect::ClientId::new(issuer.client_id.clone()),
+        issuer
+            .client_secret
+            .clone()
+            .map(openidconnect::ClientSecret::new),
+    )
+    .set_redirect_uri(redirect_uri);
+
+    let (challenge, verifier) = openidconnect::PkceCodeChallenge::new_random_sha256();
+    let (auth_url, csrf_token, nonce) = client
+        .authorize_url(
+            openidconnect::AuthenticationFlow::<openidconnect::core::CoreResponseType>::AuthorizationCode,
+            openidconnect::CsrfToken::new_random,
+            openidconnect::Nonce::new_random,
+        )
+        .add_scope(openidconnect::Scope::new("email".to_string()))
+        .add_scope(openidconnect::Scope::new("profile".to_string()))
+        .set_pkce_challenge(challenge)
+        .url();
+
+    // Capture `now` once so the session's created_at matches the
+    // eviction cutoff exactly — guards against the (very unlikely)
+    // case of the system clock advancing between two adjacent
+    // `now_seconds()` calls.
+    let now = now_seconds();
+    if state
+        .runtime
+        .oidc_sessions
+        .insert(
+            csrf_token.secret().clone(),
+            oidc::OidcLoginSession {
+                provider_id: issuer.id.clone(),
+                pkce_verifier: verifier,
+                nonce,
+                created_at_secs: now,
+            },
+            now,
+        )
+        .is_err()
+    {
+        return err(
+            StatusCode::TOO_MANY_REQUESTS,
+            ErrorCode::RateLimited.as_str(),
+            "too many in-flight OIDC logins; try again",
+        );
+    }
+
+    // `auth_url` is built from the IdP's discovered authorization
+    // endpoint — operator-trust-boundary input, not entirely under our
+    // control. Avoid panicking on a non-ASCII char in the URL: an
+    // operator who misconfigures `issuer_url` to a path with extended
+    // characters would otherwise crash the async task.
+    let location = match HeaderValue::from_str(auth_url.as_str()) {
+        Ok(v) => v,
+        Err(_) => {
+            return err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorCode::ConfigInvalid.as_str(),
+                "OIDC authorization endpoint URL is not a valid HTTP header value",
+            );
+        }
+    };
+    let mut response = Response::new(axum::body::Body::empty());
+    *response.status_mut() = StatusCode::FOUND;
+    response
+        .headers_mut()
+        .insert(axum::http::header::LOCATION, location);
+    response.headers_mut().extend(cors);
+    response
+}
+
+async fn oidc_callback_not_implemented(
+    State(state): State<AppState>,
+    AxumPath(provider): AxumPath<String>,
+    headers: HeaderMap,
+) -> Response {
+    let route = format!("/auth/oidc/{provider}/callback");
+    let cors = match state.runtime.check_boundary(&headers, &route) {
+        Ok(c) => c,
+        Err(r) => return *r,
+    };
+    json_response(
+        StatusCode::NOT_IMPLEMENTED,
+        json!({
+            "code": "UNSUPPORTED",
+            "message": "OIDC callback verification not yet implemented; tracked as a follow-up on #16",
         }),
         cors,
     )
@@ -6579,33 +6755,205 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn unsupported_routes_return_registry_errors() {
-        let state = AppState {
-            runtime: dev_runtime_no_extensions(),
-            git_state: PureRustGitState::test_default(),
+    // Deleted: `unsupported_routes_return_registry_errors`. Its only loop
+    // arm targeted `/auth/oidc/prod/callback` against the
+    // `oidc_browser_callback` surface, which was removed from
+    // `UNSUPPORTED_SURFACES` in this PR. The callback now returns 501
+    // directly from `oidc_callback_not_implemented`; that contract is
+    // covered by `oidc_callback_handler_returns_501_not_implemented`
+    // below. No coverage lost.
+
+    // ---- OIDC scaffolding handler tests (#16) ----
+
+    /// Mock that returns a pre-built `CoreProviderMetadata` instead of
+    /// fetching one over HTTP. Lets handler tests run without network.
+    struct MockOidcMetadataProvider {
+        metadata: openidconnect::core::CoreProviderMetadata,
+    }
+
+    #[async_trait::async_trait]
+    impl oidc::OidcMetadataProvider for MockOidcMetadataProvider {
+        async fn fetch(
+            &self,
+            _issuer_url: &str,
+        ) -> Result<openidconnect::core::CoreProviderMetadata, String> {
+            Ok(self.metadata.clone())
+        }
+    }
+
+    fn mock_provider_metadata() -> openidconnect::core::CoreProviderMetadata {
+        use openidconnect::core::{
+            CoreJwsSigningAlgorithm, CoreProviderMetadata, CoreResponseType,
+            CoreSubjectIdentifierType,
         };
+        use openidconnect::{
+            AuthUrl, EmptyAdditionalProviderMetadata, IssuerUrl, JsonWebKeySetUrl, ResponseTypes,
+        };
+        CoreProviderMetadata::new(
+            IssuerUrl::new("https://issuer.example.test".to_string()).unwrap(),
+            AuthUrl::new("https://issuer.example.test/authorize".to_string()).unwrap(),
+            JsonWebKeySetUrl::new("https://issuer.example.test/jwks".to_string()).unwrap(),
+            vec![ResponseTypes::new(vec![CoreResponseType::Code])],
+            vec![CoreSubjectIdentifierType::Public],
+            vec![CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256],
+            EmptyAdditionalProviderMetadata {},
+        )
+    }
 
-        for (path, expected_surface) in [("/auth/oidc/prod/callback", "oidc_browser_callback")] {
-            let response = unsupported_route(
-                State(state.clone()),
-                HeaderMap::new(),
-                Uri::from_static(path),
-            )
-            .await;
+    fn dev_runtime_with_oidc_mock() -> Arc<Runtime> {
+        let mut runtime = dev_runtime_no_extensions();
+        let inner = Arc::get_mut(&mut runtime).expect("unique Arc on fresh runtime");
+        inner.oidc_discovery = oidc::OidcDiscoveryCache::new(Box::new(MockOidcMetadataProvider {
+            metadata: mock_provider_metadata(),
+        }));
+        runtime
+    }
 
-            assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
-            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-            let payload = serde_json::from_slice::<Value>(&body).unwrap();
-            assert_eq!(
-                payload["errors"][0]["extensions"]["code"],
-                ErrorCode::Unsupported.as_str()
-            );
-            assert_eq!(
-                payload["errors"][0]["extensions"]["surface"],
-                expected_surface
+    fn origin_header_map() -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("origin", HeaderValue::from_static("http://localhost:4321"));
+        h
+    }
+
+    #[tokio::test]
+    async fn oidc_login_unknown_provider_returns_404() {
+        let runtime = dev_runtime_with_oidc_mock();
+        let response = oidc_login(
+            State(AppState {
+                runtime,
+                git_state: PureRustGitState::test_default(),
+            }),
+            AxumPath("nonexistent".to_string()),
+            origin_header_map(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(
+            response
+                .headers()
+                .contains_key("access-control-allow-origin"),
+            "404 must preserve CORS so browser can read error body, not see opaque CORS failure",
+        );
+    }
+
+    #[tokio::test]
+    async fn oidc_login_known_provider_redirects_to_idp() {
+        let runtime = dev_runtime_with_oidc_mock();
+        // `minimal_dev()` config has one issuer with id "dev".
+        let provider = runtime.config.oidc_issuers[0].id.clone();
+        let response = oidc_login(
+            State(AppState {
+                runtime: runtime.clone(),
+                git_state: PureRustGitState::test_default(),
+            }),
+            AxumPath(provider),
+            origin_header_map(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        let location = response
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("Location header set")
+            .to_str()
+            .unwrap()
+            .to_string();
+        // Mock metadata sets the auth endpoint to issuer.example.test/authorize.
+        assert!(
+            location.starts_with("https://issuer.example.test/authorize?"),
+            "Location must redirect to IdP authorization endpoint: {location}",
+        );
+        // The redirect URL must carry the required OIDC query params.
+        for expected in [
+            "client_id=",
+            "redirect_uri=",
+            "response_type=code",
+            "scope=openid",
+            "state=",
+            "nonce=",
+            "code_challenge=",
+            "code_challenge_method=S256",
+        ] {
+            assert!(
+                location.contains(expected),
+                "missing {expected} in {location}",
             );
         }
+        assert!(
+            response
+                .headers()
+                .contains_key("access-control-allow-origin"),
+            "302 must preserve CORS",
+        );
+
+        // Verify state was inserted into the session store.
+        let state_value = location
+            .split('?')
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .find(|kv| kv.starts_with("state="))
+            .unwrap()
+            .trim_start_matches("state=");
+        // The state in the URL is URL-encoded; decode minimally for the lookup.
+        let decoded_state = percent_decode_in_test(state_value);
+        assert_eq!(
+            runtime.oidc_sessions.len(),
+            1,
+            "exactly one in-flight session after login",
+        );
+        assert!(
+            runtime.oidc_sessions.take(&decoded_state).is_some(),
+            "session keyed on the state token from the redirect",
+        );
+    }
+
+    /// Minimal URL-decoder for the test's purposes (state token is base64
+    /// URL-safe so often unchanged, but `%2B` etc may appear). Tests
+    /// shouldn't pull a whole urlencoding crate in just for this.
+    fn percent_decode_in_test(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'%' && i + 2 < bytes.len() {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(h), Some(l)) = (hi, lo) {
+                    out.push(((h * 16 + l) as u8) as char);
+                    i += 3;
+                    continue;
+                }
+            }
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn oidc_callback_handler_returns_501_not_implemented() {
+        let runtime = dev_runtime_with_oidc_mock();
+        let response = oidc_callback_not_implemented(
+            State(AppState {
+                runtime,
+                git_state: PureRustGitState::test_default(),
+            }),
+            AxumPath("dev".to_string()),
+            origin_header_map(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let payload = serde_json::from_slice::<Value>(&body).unwrap();
+        assert_eq!(payload["code"], "UNSUPPORTED");
+        assert!(
+            payload["message"]
+                .as_str()
+                .unwrap()
+                .contains("not yet implemented"),
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/oidc.rs
+++ b/crates/server/src/oidc.rs
@@ -1,0 +1,286 @@
+//! OIDC scaffolding for the comtrya kernel.
+//!
+//! This module owns the in-memory state and discovery cache for the OIDC
+//! login redirect flow at `/auth/oidc/:provider/login`. It deliberately
+//! does NOT implement the callback verification path (`/auth/oidc/:provider/callback`
+//! returns 501 from a sibling handler in `main.rs`) — that work lands in a
+//! follow-up iteration of issue #16.
+//!
+//! Three types matter outside this module:
+//!
+//! * [`OidcLoginSession`] — a single in-flight PKCE+nonce pair, indexed by
+//!   the CSRF state token sent to the IdP.
+//! * [`OidcSessionStore`] — bounded in-memory map of sessions with TTL
+//!   eviction-on-insert and a 10,000-entry hard cap (insert returns Err
+//!   when the cap is hit so the caller can respond 429 cleanly).
+//! * [`OidcDiscoveryCache`] — memoizes `CoreProviderMetadata` per issuer
+//!   for the process lifetime. Operator note: if an IdP's discovery
+//!   document changes, recovery requires a process restart. Refresh-on-
+//!   rotation is a follow-up.
+//!
+//! The cache is generic over [`OidcMetadataProvider`] so tests can inject
+//! a mock that returns a pre-built metadata value without making any
+//! network requests.
+
+use openidconnect::core::CoreProviderMetadata;
+use openidconnect::{IssuerUrl, Nonce, PkceCodeVerifier};
+use std::collections::HashMap;
+use std::sync::{Mutex, RwLock};
+
+/// Per-invocation PKCE + nonce material, indexed in the session store
+/// by the CSRF state token sent to the IdP. Single-use: [`OidcSessionStore::take`]
+/// removes the entry on retrieval so a replay returns `None`. Fields are
+/// read by the callback handler in the follow-up iteration of #16;
+/// allowed-dead here because the scaffolding ships before the consumer.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct OidcLoginSession {
+    pub provider_id: String,
+    pub pkce_verifier: PkceCodeVerifier,
+    pub nonce: Nonce,
+    pub created_at_secs: u64,
+}
+
+/// 30 minutes — matches typical OIDC implementations and is generous
+/// enough for users who pause at MFA prompts. Earlier draft used 10 min;
+/// adversarial review flagged that as too aggressive for real-world
+/// authorization-code flows.
+pub(crate) const OIDC_SESSION_TTL_SECS: u64 = 30 * 60;
+
+/// Hard cap on the number of in-flight OIDC login sessions. When hit,
+/// [`OidcSessionStore::insert`] returns `Err(())` and the caller should
+/// respond 429. The cap exists to bound memory under attack — at ~200
+/// bytes per entry, 10,000 entries ≈ 2 MB. Production hardening
+/// (persistent store + edge rate limiting) is a follow-up.
+pub(crate) const OIDC_SESSION_MAX_ENTRIES: usize = 10_000;
+
+#[derive(Default, Debug)]
+pub(crate) struct OidcSessionStore {
+    inner: Mutex<HashMap<String, OidcLoginSession>>,
+}
+
+impl OidcSessionStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a session, evicting expired entries first. Returns `Err(())`
+    /// when the hard cap is hit so the caller can respond 429 without
+    /// growing the map further.
+    pub fn insert(
+        &self,
+        state: String,
+        session: OidcLoginSession,
+        now_secs: u64,
+    ) -> Result<(), ()> {
+        let mut guard = self.inner.lock().expect("oidc session lock not poisoned");
+        let cutoff = now_secs.saturating_sub(OIDC_SESSION_TTL_SECS);
+        guard.retain(|_, s| s.created_at_secs >= cutoff);
+        if guard.len() >= OIDC_SESSION_MAX_ENTRIES {
+            return Err(());
+        }
+        guard.insert(state, session);
+        Ok(())
+    }
+
+    /// Single-use retrieval — removes the entry on return. The callback
+    /// handler in the follow-up iteration of issue #16 will use this in
+    /// production; for now, gated on `cfg(test)` so it ships with the
+    /// scaffolding without triggering the dead-code lint. The next PR
+    /// removes the `cfg` gate.
+    #[cfg(test)]
+    pub fn take(&self, state: &str) -> Option<OidcLoginSession> {
+        let mut guard = self.inner.lock().expect("oidc session lock not poisoned");
+        guard.remove(state)
+    }
+
+    /// Drop all entries older than the cutoff. Useful only for tests
+    /// today; production code calls eviction implicitly via [`insert`].
+    /// `cfg(test)` for the same reason as [`take`].
+    #[cfg(test)]
+    pub fn evict_older_than(&self, cutoff_secs: u64) {
+        let mut guard = self.inner.lock().expect("oidc session lock not poisoned");
+        guard.retain(|_, s| s.created_at_secs >= cutoff_secs);
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("oidc session lock not poisoned")
+            .len()
+    }
+}
+
+/// Source of OIDC provider metadata. Production wires
+/// [`ReqwestMetadataProvider`]; tests inject a closure-backed mock so
+/// no network call happens during unit tests.
+#[async_trait::async_trait]
+pub(crate) trait OidcMetadataProvider: Send + Sync {
+    async fn fetch(&self, issuer_url: &str) -> Result<CoreProviderMetadata, String>;
+}
+
+/// Production [`OidcMetadataProvider`] backed by `reqwest`. Configured
+/// with `redirect::Policy::none()` — discovery endpoints must not
+/// redirect; if they do, surface that as an error rather than following.
+pub(crate) struct ReqwestMetadataProvider {
+    client: reqwest::Client,
+}
+
+impl ReqwestMetadataProvider {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("build OIDC discovery http client");
+        Self { client }
+    }
+}
+
+impl Default for ReqwestMetadataProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl OidcMetadataProvider for ReqwestMetadataProvider {
+    async fn fetch(&self, issuer_url: &str) -> Result<CoreProviderMetadata, String> {
+        let issuer = IssuerUrl::new(issuer_url.to_string())
+            .map_err(|e| format!("invalid OIDC issuer URL {issuer_url}: {e}"))?;
+        CoreProviderMetadata::discover_async(issuer, &self.client)
+            .await
+            .map_err(|e| format!("OIDC discovery failed for {issuer_url}: {e}"))
+    }
+}
+
+/// Process-lifetime cache of [`CoreProviderMetadata`] keyed by provider
+/// id. No TTL in v1 — refresh requires a process restart, which is fine
+/// for the production-testbed posture. Refresh-on-rotation is a
+/// follow-up.
+pub(crate) struct OidcDiscoveryCache {
+    inner: RwLock<HashMap<String, CoreProviderMetadata>>,
+    provider: Box<dyn OidcMetadataProvider>,
+}
+
+impl std::fmt::Debug for OidcDiscoveryCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `dyn OidcMetadataProvider` is not Debug; surface only what is.
+        f.debug_struct("OidcDiscoveryCache")
+            .field("cached_issuers", &self.inner.read().ok().map(|g| g.len()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl OidcDiscoveryCache {
+    pub fn new(provider: Box<dyn OidcMetadataProvider>) -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            provider,
+        }
+    }
+
+    /// Production constructor — uses `reqwest` under the hood.
+    pub fn with_reqwest() -> Self {
+        Self::new(Box::new(ReqwestMetadataProvider::new()))
+    }
+
+    pub async fn get_or_fetch(
+        &self,
+        issuer_id: &str,
+        issuer_url: &str,
+    ) -> Result<CoreProviderMetadata, String> {
+        if let Some(cached) = self
+            .inner
+            .read()
+            .expect("oidc discovery lock not poisoned")
+            .get(issuer_id)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+        let fetched = self.provider.fetch(issuer_url).await?;
+        self.inner
+            .write()
+            .expect("oidc discovery lock not poisoned")
+            .insert(issuer_id.to_string(), fetched.clone());
+        Ok(fetched)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openidconnect::{Nonce, PkceCodeChallenge};
+
+    fn fake_session(provider_id: &str, age_secs: u64, now_secs: u64) -> (String, OidcLoginSession) {
+        let (_chal, verifier) = PkceCodeChallenge::new_random_sha256();
+        let state = format!("state-{provider_id}-{age_secs}");
+        let session = OidcLoginSession {
+            provider_id: provider_id.to_string(),
+            pkce_verifier: verifier,
+            nonce: Nonce::new_random(),
+            created_at_secs: now_secs - age_secs,
+        };
+        (state, session)
+    }
+
+    #[test]
+    fn oidc_session_store_take_is_single_use() {
+        let store = OidcSessionStore::new();
+        let now = 1_000_000;
+        let (state, session) = fake_session("dev", 0, now);
+        store.insert(state.clone(), session, now).unwrap();
+
+        assert!(store.take(&state).is_some(), "first take returns Some");
+        assert!(store.take(&state).is_none(), "second take returns None");
+    }
+
+    #[test]
+    fn oidc_session_store_evicts_expired_on_insert() {
+        let store = OidcSessionStore::new();
+        let now = 1_000_000;
+        let (old_state, old_session) = fake_session("dev", OIDC_SESSION_TTL_SECS + 1, now);
+        store
+            .inner
+            .lock()
+            .unwrap()
+            .insert(old_state.clone(), old_session);
+        assert_eq!(store.len(), 1, "old session present before insert");
+
+        let (new_state, new_session) = fake_session("dev", 0, now);
+        store.insert(new_state, new_session, now).unwrap();
+
+        assert!(
+            store.take(&old_state).is_none(),
+            "old session evicted on insert"
+        );
+    }
+
+    #[test]
+    fn oidc_session_store_returns_err_when_cap_hit() {
+        let store = OidcSessionStore::new();
+        let now = 1_000_000;
+
+        // Fill to cap with fresh entries (eviction won't help).
+        for i in 0..OIDC_SESSION_MAX_ENTRIES {
+            let (_chal, verifier) = PkceCodeChallenge::new_random_sha256();
+            store.inner.lock().unwrap().insert(
+                format!("state-{i}"),
+                OidcLoginSession {
+                    provider_id: "dev".to_string(),
+                    pkce_verifier: verifier,
+                    nonce: Nonce::new_random(),
+                    created_at_secs: now,
+                },
+            );
+        }
+        assert_eq!(store.len(), OIDC_SESSION_MAX_ENTRIES);
+
+        let (state, session) = fake_session("dev", 0, now);
+        assert!(
+            store.insert(state, session, now).is_err(),
+            "insert at cap returns Err"
+        );
+    }
+}


### PR DESCRIPTION
Addresses #16 (login-redirect scaffolding only — see "Scope" below). Use `Closes #16` only after the callback handler, SDK integration, lockdown, and operator-code-grant removal all land in follow-up iterations.

## Summary

First slice of the OIDC work tracked in #16. A user can now hit `GET /auth/oidc/:provider/login`, the server constructs a proper OIDC authorization URL with PKCE/state/nonce per the configured `OidcIssuerConfig`, and the user is 302-redirected to the IdP's authorization endpoint. The callback at `GET /auth/oidc/:provider/callback` returns `501 Not Implemented` with a clear pointer to the next iteration. No actual sign-in completes yet.

## Acceptance criteria (subset of #16)

- [x] **Login redirect** — `GET /auth/oidc/:provider/login` looks up the provider in `InstanceConfig.oidc_issuers`, fetches & memoizes the discovery doc, generates PKCE+state+nonce, stores the state, returns 302 to the IdP's `authorization_endpoint` with all required OIDC query params.
- [x] **CORS preservation** — every error path (404 unknown provider, 500 malformed redirect URL, 502 discovery failure, 429 cap hit) returns CORS headers so cross-origin browsers see the real status code, not an opaque CORS failure.
- [x] **Bounded growth** — 30-min TTL on in-flight session state + 10,000-entry hard cap. Insert evicts expired entries first, then returns Err triggering 429 if the cap is hit.
- [x] **Callback stub** — `GET /auth/oidc/:provider/callback` returns `501 {"code":"UNSUPPORTED","message":"...follow-up..."}` with CORS preserved.
- [x] **Test-injectable discovery** — `OidcMetadataProvider` trait abstracts the HTTP fetch; production uses `ReqwestMetadataProvider`, tests use a closure-backed mock returning pre-built `CoreProviderMetadata`. No network calls in tests.
- [ ] **Callback handler** — code exchange, JWKS fetch, ID token verification, `AuthService::login` invocation, session cookie issuance. **Follow-up iteration of #16.**
- [ ] **SDK integration** — wire login URL into the shell's "Sign in" button; persist post-callback bearer token. **Follow-up.**
- [ ] **atproto/Bluesky support** — PAR + PKCE + DPoP per the atproto OAuth profile (Google is OIDC-standard; atproto adds its own quirks). **Follow-up.**
- [ ] **Read-path + `/api/ops/*` lockdown against Anonymous** — depends on SDK being able to authenticate. **Follow-up.**
- [ ] **`urn:comtrya:grant:operator-code` removal** — depends on OIDC being the only sign-in path. **Follow-up.**

## How it works

New module `crates/server/src/oidc.rs`:

- `OidcLoginSession` — single in-flight `(provider_id, pkce_verifier, nonce, created_at_secs)`.
- `OidcSessionStore` — `Mutex<HashMap<String, OidcLoginSession>>`. `insert(state, session, now_secs)` evicts entries older than `OIDC_SESSION_TTL_SECS (30 min)`, then refuses (`Err(())`) when at `OIDC_SESSION_MAX_ENTRIES (10_000)`.
- `OidcMetadataProvider` async trait + `ReqwestMetadataProvider` (production, `Policy::none()`) + `OidcDiscoveryCache` (process-lifetime memoization).

New handlers in `main.rs`:

- `oidc_login` — opens with a CORS-preserving `err(status, code, msg)` closure; every early return uses it. Captures `now = now_seconds()` once. Builds the authorization URL via `openidconnect::core::CoreClient::authorize_url`, stores session, 302-redirects.
- `oidc_callback_not_implemented` — returns 501 with `{"code":"UNSUPPORTED","message":"..."}`.

Router wires both before the existing `/auth/oidc/*path` wildcard fallback.

## Front-end integration note

**Do not wire a frontend login button to `/auth/oidc/:provider/login` in this PR.** The callback returns 501 — clicking the button would redirect to Google, sign in successfully, and hit a dead end. Frontend wiring lands together with the callback handler.

## Test Plan

6 tests across `crates/server/src/oidc.rs` (3 store-level) and `crates/server/src/main.rs` (3 handler-level):

- [x] `oidc::tests::oidc_session_store_take_is_single_use`
- [x] `oidc::tests::oidc_session_store_evicts_expired_on_insert`
- [x] `oidc::tests::oidc_session_store_returns_err_when_cap_hit`
- [x] `tests::oidc_login_unknown_provider_returns_404` (asserts CORS header present on 404)
- [x] `tests::oidc_login_known_provider_redirects_to_idp` (asserts 302, Location to mock's authorization_endpoint, all required OIDC query params present, state inserted into store, CORS preserved)
- [x] `tests::oidc_callback_handler_returns_501_not_implemented`

Run:
```
cargo test --bin comtrya-server   → 119 passed, 0 failed (was 114 + 6 new − 1 deleted)
cargo clippy --workspace -- -D warnings → clean
cargo fmt --check                       → clean
```

## Honest disclosures

1. **Branched off `chore-ci-green` (PR #22), not `v3`.** v3's test baseline has 18 known failures + 2 compile errors. PR #22 is the chore that fixes them. Once #22 lands, rebase this PR onto v3.

2. **`#[allow(dead_code)]` on `OidcLoginSession` fields** (`provider_id`, `pkce_verifier`, `nonce`, `created_at_secs`). The fields are *written* by `oidc_login` but not *read* until the callback PR. Per CLAUDE.md, `#[allow]` requires PR-description justification: the fields are scaffolding for the callback handler in the immediately-following iteration on #16. The follow-up PR removes the allow when it adds the read. Two related methods (`OidcSessionStore::take` and `evict_older_than`) avoid the allow by using `#[cfg(test)]` instead — they're only consumed by tests today, and the callback PR removes the cfg gate.

3. **Kept `async-trait = "0.1"` dependency** rather than switching to native async-fn-in-trait. Edition 2024 supports `async fn` in traits, but native async-in-trait is not fully `dyn`-compatible in Rust 1.85 (the trait must specify `Send` future bounds explicitly, and `Box<dyn AsyncTrait>` requires `for<'a>` lifetime gymnastics). The `OidcDiscoveryCache.provider: Box<dyn OidcMetadataProvider>` field would otherwise have to be replaced with a generic param threaded through `Runtime`, which is a large refactor for a single Box-allocation-per-discovery-call savings (discovery fires roughly once per minute under load). Documented as a follow-up if/when async-fn-in-trait's dyn story matures.

4. **No browser verification.** Server-only change; no Vue/TS/asset files in the diff.

5. **Scope: server-side login redirect ONLY.** This is the smallest viable slice of #16 — picking the OIDC crate, defining the config-driven provider registry, and proving the redirect path works end-to-end against a mock IdP. Everything else (callback verification, JWKS, session issuance, SDK rewiring, IdP-specific atproto flow, lockdown, operator-code removal) is in #16's existing checklist for follow-ups.

## Process trail

- Stage 1 (planning): 3 review rounds. Round 1: 4 compile errors (`extensions(cors)` typemap, `?` on RedirectUrl::new, missing `now_ms()`, missing `error_response_with_cors`) + 3 important (reqwest::Client setup, UNSUPPORTED_SURFACES gap, 10-min TTL too short) + 3 critical scope + 4 recommended. Round 2: 2 nits (Risks prose still said "10 min", Change 8 indecision) + 2 new findings (CORS on error paths drops headers — real cross-origin bug; test #4 stale prose). Round 3: SHIP.
- Stage 2 (implementation): 2 review rounds. Round 1: wrong error code, double `now_seconds()`, `#[allow(dead_code)]` violations, async-trait dep concern, reachable HeaderValue panic. Round 2: SHIP after 5 fixes.
- Stage 3 (final review): 3 reviewers (acceptance / regressions / PR honesty) pending at PR open.
